### PR TITLE
Decimal optimization

### DIFF
--- a/examples/snake.nk
+++ b/examples/snake.nk
@@ -47,8 +47,8 @@ of nested block calls. Phew!
   ] @: opp?
 
   [ "( -- ): set X, Y to random values in screen bounds."
-    0 console:width  randFromTo =: x
-    0 console:height randFromTo =: y
+    0 console:width  1 - randFromTo =: x
+    0 console:height 1 - randFromTo =: y
   ] @: random
 
   [

--- a/src/novika/forms/decimal.cr
+++ b/src/novika/forms/decimal.cr
@@ -1,84 +1,237 @@
+require "big"
+
 module Novika
   # A representation for decimal numbers inside Novika.
-  struct Decimal
+  abstract struct Decimal
     include Form
     extend HasDesc
 
-    # Returns the underlying big decimal value.
-    protected getter val : BigDecimal
-
-    def initialize(@val : BigDecimal)
+    # Initializes a decimal number from *number*.
+    def self.new(number : Int128 | BigInt)
+      LargeDecimal.new(number)
     end
 
-    def initialize(object : String | Number)
-      initialize(object.to_big_d)
+    # :ditto:
+    def self.new(number : Int)
+      SmallDecimal.new(number)
+    end
+
+    # :ditto:
+    def self.new(number : Float)
+      DecimalFloat.new(number)
+    end
+
+    # Initializes a decimal number from *string*.
+    def self.new(string : String) : Decimal
+      if string.includes?('.')
+        DecimalFloat.new(string)
+      elsif i64 = string.to_i64?
+        SmallDecimal.new(i64)
+      else
+        LargeDecimal.new(string)
+      end
     end
 
     def desc(io : IO)
-      io << "decimal number " << val
+      io << "decimal number " << value
     end
 
     def self.desc(io : IO)
       io << "a decimal number"
     end
 
+    # Returns the underlying numeric value.
+    protected abstract def value : Int64 | BigInt | BigFloat
+
     # Returns whether this decimal is zero.
-    def zero? : Bool
-      val.zero?
+    def zero?
+      value.zero?
     end
 
-    # Downgrades this decimal into an integer (`Int32`). Dies
-    # if too large.
-    def to_i : Int32
-      val.to_i
-    rescue OverflowError
-      die("conversion overflow when downgrading a decimal")
+    # Negates this decimal.
+    def - : Decimal
+      self.class.new(-value)
     end
 
-    # Returns the sum of this and *other* decimal numbers.
-    def +(other : Decimal) : Decimal
-      Decimal.new(val + other.val)
-    end
-
-    # Returns the difference between this and *other* decimal numbers.
+    # Returns the difference of this decimal from *other*.
     def -(other : Decimal) : Decimal
-      Decimal.new(val - other.val)
+      self + -other
     end
 
-    # Returns the product of this and *other* decimal numbers.
-    def *(other : Decimal) : Decimal
-      Decimal.new(val * other.val)
-    end
+    {% for op in %w(+ * / %) %}
+      # Converts both operands to floats and applies the#
+      # corresponding operation
+      #
+      # Note: this method is reached only when `DecimalInt` or
+      # `DecimalFloat` couldn't handle `{{op}}` themselves.
+      def {{op.id}}(other : Decimal) : Decimal
+        to_float {{op.id}} other.to_float
+      end
+    {% end %}
 
-    # Returns the quotient of this and *other* decimal numbers.
-    def /(other : Decimal) : Decimal
-      Decimal.new(val / other.val)
-    end
-
-    # Returns the remainder of this and *other* decimal numbers.
-    def %(other : Decimal) : Decimal
-      Decimal.new(val.to_big_i % other.val.to_big_i)
+    # Returns decimal float 0.
+    def //(other : Decimal) : Decimal
+      DecimalFloat.new(0)
     end
 
     # Returns whether this decimal is smaller than *other*.
     def <(other : Decimal) : Bool
-      val < other.val
+      value < other.value
     end
 
-    # Rounds this decimal.
-    def round : Decimal
-      Decimal.new(val.round)
+    # Converts this decimal to `Int32`. Dies upon overflow.
+    def to_i : Int32
+      value.to_i32
+    rescue OverflowError
+      die("integer conversion overflow")
     end
 
-    # Truncates this decimal.
-    def trunc : Decimal
-      Decimal.new(val.trunc)
+    # Converts this decimal to `DecimalFloat`.
+    def to_float
+      DecimalFloat.new(value)
     end
 
     def to_s(io)
-      io << val
+      io << value
+    end
+  end
+
+  # Holds floating-point decimals.
+  struct DecimalFloat < Decimal
+    protected getter value : BigFloat
+
+    def initialize(object)
+      @value = object.to_big_f
     end
 
-    def_equals_and_hash val
+    {% for op in %w(+ * / %) %}
+      # Applies `{{op.id}}` on this and *other* float values.
+      def {{op.id}}(other : DecimalFloat) : DecimalFloat
+        DecimalFloat.new(value {{op.id}} other.value)
+      end
+    {% end %}
+
+    # Rounds the contents of this float and returns the
+    # resulting `DecimalInt`.
+    def round : DecimalInt
+      rounded = value.round
+      if Int64::MIN <= rounded <= Int64::MAX
+        SmallDecimal.new(rounded)
+      else
+        LargeDecimal.new(rounded)
+      end
+    end
+
+    # Truncates the contents of this float and returns the
+    # resulting `DecimalInt`.
+    def trunc : DecimalInt
+      truncated = value.round
+      if Int64::MIN <= truncated <= Int64::MAX
+        SmallDecimal.new(truncated)
+      else
+        LargeDecimal.new(truncated)
+      end
+    end
+  end
+
+  # Holds integer decimals.
+  abstract struct DecimalInt < Decimal
+    # Small decimal together with large decimal leads to this
+    # method being called.
+    private def promote(other : LargeDecimal)
+      yield to_large, other
+    end
+
+    # Large decimal together with small decimal leads to this
+    # method being called.
+    private def promote(other : SmallDecimal)
+      yield self, other.to_large
+    end
+
+    {% for op in %w(+ * // %) %}
+      # Promotes either type (*other* to `LargeDecimal` or self to
+      # `LargeDecimal`) and applies the corresponding operator.
+      def {{op.id}}(other : DecimalInt) : DecimalInt
+        promote(other) { |a, b| a {{op.id}} b }
+      end
+    {% end %}
+
+    # If self is divisible by *other*, returns `DecimalInt`
+    # result, else, `DecimalFloat` result.
+    def /(other : DecimalInt) : Decimal
+      (self % other).zero? ? self // other : super
+    end
+
+    # Converts decimal to a large decimal.
+    def to_large : LargeDecimal
+      LargeDecimal.new(value)
+    end
+
+    # Returns self (integers are already round).
+    def round : self
+      self
+    end
+
+    # Returns self (integers are already truncated).
+    def trunc : self
+      self
+    end
+  end
+
+  # Holds small (Int64) integers.
+  struct SmallDecimal < DecimalInt
+    protected getter value : Int64
+
+    def initialize(object)
+      @value = object.to_i64
+    end
+
+    # Adds with an overflow check, and promotes automatically
+    # to `LargeDecimal` in case of an overflow.
+    def +(other : SmallDecimal) : DecimalInt
+      sum = value &+ other.value
+      overflow = (value < 0 && other.value < 0 && sum >= 0) ||
+                 (value >= 0 && other.value >= 0 && sum < 0)
+      overflow ? to_large + other.to_large : SmallDecimal.new(sum)
+    end
+
+    # Multiplies with an overflow check, and promotes automatically
+    # to `LargeDecimal` in case of an overflow.
+    def *(other : SmallDecimal) : DecimalInt
+      prod = value &* other.value
+      overflow = !(value == 0 || other.value == 0) && value != prod / other.value
+      overflow ? to_large * other.to_large : SmallDecimal.new(prod)
+    end
+
+    # Divides with an overflow check, and promotes automatically
+    # to `LargeDecimal` in case of an overflow.
+    def //(other : SmallDecimal) : DecimalInt
+      if value == Int64::MIN && other.value == -1
+        to_large // other.to_large
+      else
+        SmallDecimal.new(value // other.value)
+      end
+    end
+
+    # Returns the remainder from dividing this by *other*.
+    def %(other : SmallDecimal) : SmallDecimal
+      SmallDecimal.new(value % other.value)
+    end
+  end
+
+  # Holds large (BigInt) integers.
+  struct LargeDecimal < DecimalInt
+    protected getter value : BigInt
+
+    def initialize(object)
+      @value = object.to_big_i
+    end
+
+    {% for op in %w(+ * // %) %}
+      # Applies `{{op.id}}` on this and *other* decimal values.
+      def {{op.id}}(other : LargeDecimal) : LargeDecimal
+        LargeDecimal.new(value {{op.id}} other.value)
+      end
+    {% end %}
   end
 end


### PR DESCRIPTION
This particular implementation isn't 400x faster, nor 100x, nor even 10x, nor even 2x. It's about 20% faster, as small benchmarks and overall experimentation shows. E.g., looping a million times with old `Decimal` and new `Decimal` (**in Crystal**):

```
decimal old increment  13.20  ( 75.75ms) (± 5.93%)  61.0MB/op  54.68× slower
decimal new increment 721.82  (  1.39ms) (± 1.06%)    0.0B/op        fastest
```

But this is only a silly little benchmark. A simple loop `100000 times: [ ]` **in Novika** now runs in about 17s instead of 20s, on my machine (Ryzen 3 2200g). The main thing is that we have 0 memory usage at most times now for numbers, while before even in simplest scenarios we had a small, but usage nevertheless.

This has almost no effect on the big picture, though. So for now, let this be is on hold, because it introduces complexity and possibility of bugs (the snake fix commit may be a bug in snake, or in the decimal implementation; the fact is that it has to do with random numbers, and there is no sure way to trigger it other than play snake for eternity).

Closes #1 