### PR TITLE
Break/continue fix

### DIFF
--- a/core/block.nk
+++ b/core/block.nk
@@ -284,6 +284,24 @@
 
 
 [ """( Lb B -- ): opens Block with each item of List block on
+   top of a new stack, and its index below. List block is unchanged.
+   `break` and `next` are available.
+
+  >>> [ 1 2 3 ] [ 2echo ] eachWithIndex
+  STDOUT: 0 1
+  STDOUT: 1 2
+  STDOUT: 2 3
+  """
+  $: body $: list 0 $: index
+
+  body [ index list count < ] [
+    index list index fromLeft 2enclose swap hydrate
+    index 1 + =: index
+  ] createDetachedLoop open
+] @: eachWithIndex
+
+
+[ """( Lb B -- ): opens Block with each item of List block on
    top of a new stack. List block is unchanged. `break` and
    `next` are available.
 
@@ -310,6 +328,17 @@
   """
   ahead eject each
 ] @: each:
+
+
+[ """( Lb each: B -- ): infix version of `eachWithIndex`.
+
+  >>> [ 1 2 3 ] eachWithIndex: [ 2echo ]
+  STDOUT: 0 1
+  STDOUT: 1 2
+  STDOUT: 2 3
+  """
+  ahead eject eachWithIndex
+] @: eachWithIndex:
 
 
 [ """( Lb B -- ): opens Block with pairs of items from List block

--- a/core/block.nk
+++ b/core/block.nk
@@ -742,6 +742,10 @@
   >>> [ 1 2 3 ] minmax
   === 1 3
   """
+
+  "NOTE: this is separate from minmaxBy for performance reasons only;
+   otherwise, having `[ ] minmaxBy` would be sufficient here."
+
   dup empty? => [ 'Cannot minmax an empty block' die ]
 
   dup 0 fromLeft
@@ -791,19 +795,22 @@
 ] @: sum
 
 
-[ """( Lb T -- Min Max ): leaves the minimum and maximum
-   values in List block. Numeric values are obtained via the
-   Transformation block, which is opened with each element
-   of List block on top of an empty stack. If List block is
-   empty, dies, so make sure to handle that yourself.
+[ """( Lb T -- Min Max ): leaves the minimum and maximum values
+   in List block. Decimal values are obtained via the Transformation
+   block, which is opened with each element of List block on top
+   of an empty stack. If List block is empty, dies, so make sure
+   to handle that yourself.
 
-  >>> [ 1 2 3 ] [ ] minmax
+  >>> [ ] [ ] minmaxBy
+  === [dies]
+
+  >>> [ 1 2 3 ] [ ] minmaxBy
   === 1 3
 
   >>> [ 'A short quote' 'A loooonger quote' 'Veeeeeeeeeeery long quote' ] [ charCount ] minmax
   === 'A short string' 'Veeeeeeeeeeery long string'
   """
-  dup empty? => [ 'here' echo drop minmax ^ ] $: transformer
+  dup empty? => [ drop minmax ^ ] $: transformer
   dup empty? => [ 'Cannot minmax an empty block' die ]
 
   dup 0 fromLeft "Get the first item in the List block."
@@ -825,28 +832,28 @@
 
 [ """( Lb T -- Min ): leaves the minimum value in List block. Each
    element of List block is transformed using Transformation
-   block. See `minmax`.
+   block. See `minmaxBy`.
 
-  >>> [ 1 2 3 ] [ ] min
+  >>> [ 1 2 3 ] [ ] minBy
   === 1
   """
-  minmax drop
+  minmaxBy drop
 ] @: minBy
 
 
 [ """( Lb T -- Max ): leaves the maximum value in List block. Each
    element of List block is transformed using Transformation
-   block. See `minmax`.
+   block. See `minmaxBy`.
 
-  >>> [ 1 2 3 ] [ ] max
+  >>> [ 1 2 3 ] [ ] maxBy
   === 3
   """
-  minmax nip
+  minmaxBy nip
 ] @: maxBy
 
 
 [ """( Lb T -- Sum ): leaves Sum of List block elements transformed
-   into decimals by Transformation block. Similar to `minmax`.
+   into decimals by Transformation block. Similar to `minmaxBy`.
 
   >>> [ 'a' 'aaa' 'aa' ] [ charCount ] sumBy
   === 6
@@ -858,7 +865,9 @@
 
 
 [ """( N B -- Lb ): leaves a List block with N results of opening
-   Block with the current N. `break` and `next` are available.
+   Block with the current N. Basically a combo of `times` and `map`.
+   `break` and `next` are available. The current result is skipped
+   if stack is empty after opening Block.
 
   >>> 3 [ readLine [ stack swap slurp ] [ drop 0 ] br ] collect
   INPUT: 0 3
@@ -874,7 +883,8 @@
 
   block  [ current max < ]
   [
-    current swap open result gulp
+    current enclose swap there dup empty? not =>
+      [ cherry result gulp ]
     current 1 + =: current
   ] createDetachedLoop open
 
@@ -909,7 +919,7 @@
 ] @: range
 
 
-[ """( B to: E -- Rb ): infix version of `between`.
+[ """( B to: E -- Rb ): infix version of `range`.
 
   >>> 1 to: 100
   === [ 1 2 3 ... 98 99 100 | ]
@@ -949,7 +959,7 @@
   >>> [ 1 2 3 ] [ 4 5 6 ]
   === [ 1 2 3 4 5 6 ] (a new block!)
   """
-  shallowCopy concat!
+  <| shallowCopy |> concat!
 ] @: concat
 
 

--- a/core/block.nk
+++ b/core/block.nk
@@ -641,14 +641,13 @@
   >>> [ 1 2 ] [ 3 ] zip
   [dies]
   """
-  $: b $: a
+  $: b $: a a count $: aCount
 
-  a count dup
-  b count = not => [ 'counts must be equal with zip, otherwise use zipWithDefault' die ]
+  aCount b count = not => [ 'counts must be equal with zip, otherwise use zipWithDefault' die ]
 
   [ ] $: result
 
-  "a count" times: [ dup
+  aCount times: [ dup
     a swap fromLeft swap
     b swap fromLeft 2enclose
     result gulp

--- a/core/block.nk
+++ b/core/block.nk
@@ -446,7 +446,10 @@
 
   block [ index list count < ]
   [
-    list index fromLeft enclose swap there cherry result gulp
+    list index fromLeft enclose swap there dup empty?
+      [ "No result: probably the user wants it out." drop ]
+      [ cherry result gulp ]
+    br
     index 1 + =: index
   ] createDetachedLoop open
 
@@ -484,7 +487,10 @@
 
   block [ index list count < ]
   [
-    list index fromLeft dup enclose rot there cherry => [ result gulp ]
+    list index fromLeft dup enclose rot there dup empty?
+      [ "No result: probably the user wants it out." drop ]
+      [ cherry => [ result gulp ] ]
+    br
     index 1 + =: index
   ] createDetachedLoop open
 

--- a/core/block.nk
+++ b/core/block.nk
@@ -218,7 +218,7 @@
 
 [ """( Lb B -- Lb ): slides cursor in List block from left to right,
    in steps of one. Opens Block with List block as the stack *after*
-   each step. Leaves List block. `break` and `continue` are available.
+   each step. Leaves List block. `break` and `next` are available.
 
   >>> [ 1 2 3 ] dup 1 |to [ + ] |slideRight
 
@@ -238,13 +238,13 @@
 
   === [ 6 ]
   """
-  newWithBreakAndContinue $: body $: list
+  $: body $: list
 
-  until: [ list dup |at over count = ]
-  [
-    list dup |at 1 + |to
-    list body hydrate
-  ]
+  body
+  [ list dup |at over count < ]
+  [ list dup |at 1 + |to
+    list swap hydrate ]
+  createDetachedLoop open
 
   list
 ] @: |slideRight
@@ -256,19 +256,23 @@
 
 
 [ "( Lb B -- Lb ): similar to `|->`, but slides the cursor
-   from right to left. Consult `|slideRight`."
-  newWithBreakAndContinue $: body $: list
+   from right to left. Consult `|slideRight`. `break` and
+   `next` are available."
+  $: body $: list
 
-  until: [ list |at 0 = ]
-  [
-    list count $: tmp
-    list body hydrate
+  body
+  [ list |at 0 > ]
+  [ list count $: tmp
+    list swap hydrate
     list count tmp >= => [
-      "If the amount of items in the list has not changed, or
-       increased, slide leftwards."
-       list dup |at 1 - |to
+      "If the amount of items in the list has not changed,
+       or increased, slide leftwards by delta + 1, meaning
+       by the amount of items added, plus once leftwards to
+       maintain the movement left."
+      list count tmp - 1 + $: delta
+      list dup |at delta - |to
     ]
-  ]
+  ] createDetachedLoop open
 
   list
 ] @: |slideLeft
@@ -281,18 +285,19 @@
 
 [ """( Lb B -- ): opens Block with each item of List block on
    top of a new stack. List block is unchanged. `break` and
-   `continue` are available.
+   `next` are available.
 
   >>> [ 1 2 3 ] [ echo ] each
   STDOUT: 1
   STDOUT: 2
   STDOUT: 3
   """
-  newWithBreakAndContinue $: block
+  $: body $: list 0 $: index
 
-  shallowCopy dup 0 |to
-    |-> [ dup enclose block hydrate ]
-  drop
+  body [ index list count < ] [
+    list index fromLeft enclose swap hydrate
+    index 1 + =: index
+  ] createDetachedLoop open
 ] @: each
 
 
@@ -308,7 +313,7 @@
 
 
 [ """( Lb B -- ): opens Block with pairs of items from List block
-   on top of an empty stack.
+   on top of an empty stack. `break` and `next` are available.
 
   >>> [ ] [ + echo ] pairs
   [Does nothing]
@@ -321,18 +326,20 @@
   STDOUT: 3 (i.e., 1 + 2)
   STDOUT: 7 (i.e., 3 + 4)
   """
-  $: block $: list
+  $: block
 
-  list empty? => [ ^ ]
+  dup empty? => [ drop ^ ]
+  dup count odd? => [ 'for pairs to work, there should be an even count of items in block' die ]
 
-  list count odd? =>
-    [ 'for pairs to work, there should be an even count of items in block' die ]
+  $: list 0 $: index
 
-  list shallowCopy dup 0 |to
-    "Force cursor at 0. Also, we can safely drop below (and we do),
-     since the block copy is ours thanks to `shallowCopy`."
-    |-> [ |> 2enclose block hydrate ]
-  drop
+  block [ index list count < ]
+  [
+    list index     fromLeft
+    list index 1 + fromLeft
+    2enclose swap hydrate
+    index 2 + =: index
+  ] createDetachedLoop open
 ] @: pairs
 
 
@@ -347,7 +354,8 @@
 
 
 [ """( Lb B -- ): opens Block with consequtive pairs of items
-   from List block on top of an empty stack.
+   from List block on top of an empty stack. `break` and `next`
+   are available.
 
   >>> [ ] [ + echo ] consPairs
   >>> [ 1 ] [ + echo ] consPairs
@@ -360,11 +368,19 @@
   STDOUT: 3 (i.e., 1 + 2)
   STDOUT: 5 (i.e., 2 + 3)
   """
-  $: block "( Lb )" dup empty? => [ drop ^ ]
+  $: block
 
-  shallowCopy dup 1 |to
-    |-> [ 2dup 2enclose block hydrate ]
-  drop
+  dup empty? => [ drop ^ ]
+
+  $: list 0 $: index
+
+  block [ index list count 1 - < ]
+  [
+    list index     fromLeft
+    list index 1 + fromLeft
+    2enclose swap hydrate
+    index 1 + =: index
+  ] createDetachedLoop open
 ] @: consPairs
 
 
@@ -378,24 +394,34 @@
 ] @: consPairs:
 
 
-[ """( Lb B -- MLb ): opens Block with each item of List block
+[ """( Lb B -- Mlb ): opens Block with each item of List block
    on top of an empty stack. Replaces item in List block with
    Block's stack top after opening it. Leaves the resulting
-   Modified version of List block.
+   Modified version of List block. `break` and `next` are available.
 
   >>> [ 1 2 3 ] [ 1 + ] map
-  === [ 2 3 4 | ]
+  === [ 2 3 4 | ] (a different block!)
 
   >>> [ 1 2 3 ] $: a
   >>> a [ 1 + ] map
-  === [ 2 3 4 | ]
+  === [ 2 3 4 | ] (a different block!)
 
   >>> a
   === [ 1 2 3 | ]
   """
-  $: block "( Lb )"
+  $: block $: list [ ] $: result
 
-  shallowCopy dup 0 |to |-> [ enclose block there cherry ]
+  list empty? => [ result ^ ]
+
+  0 $: index
+
+  block [ index list count < ]
+  [
+    list index fromLeft enclose swap there cherry result gulp
+    index 1 + =: index
+  ] createDetachedLoop open
+
+  result
 ] @: map
 
 
@@ -410,6 +436,7 @@
 [ """( Lb B -- MLb ): opens Block with each item of List block
    on top of an empty stack. Removes that item in Modified List
    block if Block's stack top is false after it was opened.
+   `break` and `next` are available.
 
   >>> [ ] [ 100 > ] only
   === [ | ] (a different block!)
@@ -420,14 +447,19 @@
   >>> [ 1 100 2 300 4 600 10 ] [ 100 > ] only
   === [ 300 600 | ]
   """
-  $: block
+  $: block $: list [ ] $: result
 
-  shallowCopy dup 0 |to |-> [ $: item
-    item enclose block there cherry
-      [ item ] "Truthy value on Block's ToS: leave item."
-      [      ] "Falsey value on Block's ToS: drop item."
-    br
-  ]
+  list empty? => [ result ^ ]
+
+  0 $: index
+
+  block [ index list count < ]
+  [
+    list index fromLeft dup enclose rot there cherry => [ result gulp ]
+    index 1 + =: index
+  ] createDetachedLoop open
+
+  result
 ] @: only
 
 
@@ -440,10 +472,10 @@
 ] @: only:
 
 
-[ """( Lb B M -- M ): reduces (google it if you don't know) List
-   block using Block. Block is opened with Memo, current item on
-   top of an empty stack. Memo is updated to Block's value after
-   Block's opened.
+[ """( Lb B M -- M ): reduces List block using Block. Block
+   is opened with Memo, current item on top of an empty stack.
+   Memo is updated to Block's value after Block is opened.
+   `break` and `next` are available.
 
   >>> [ ] [ + ] 0 reduce
   === 0
@@ -457,17 +489,25 @@
   >>> [ 'Hellope, ' 'Europe!' ' ' 'Huh?' ] [ stitch ] '' reduce
   === 'Hellope, Europe! Huh?'
   """
-  $: default @: block
+  $: memo $: block $: list
 
-  shallowCopy dup 0 |to
-    default << |-> [ block ]
-  cherry
+  list empty? => [ memo ^ ]
+
+  0 $: index
+
+  block [ index list count < ]
+  [
+    memo list index fromLeft 2enclose swap there cherry =: memo
+    index 1 + =: index
+  ] createDetachedLoop open
+
+  memo
 ] @: reduce
 
 
 [ """( Lb B -- A ): leaves the Amount of items for which Block,
    when opened with an item on top of an empty stack, returns
-   a truthy form.
+   a truthy form. `break` and `next` are available.
 
   >>> [ 1 2 3 ] [ 2 > ] amount
   === 1 (i.e., 3)
@@ -478,11 +518,20 @@
   >>> [ 1 5000 2 4400 1 100 102 ] [ 100 <= ] amount
   === 4 (i.e., 1, 2, 1, 100)
   """
-  @: block 0 $: amt
+  $: block $: list
+
+  list empty? => [ 0 ^ ]
+
+  0 $: amt
+  0 $: index
 
   "Go thru each item and check if block opens to true there,
    if it does, increment the count."
-  each: [ block => [ amt 1 + =: amt ] ]
+  block [ index list count < ]
+  [
+    list index fromLeft enclose swap there cherry => [ amt 1 + =: amt ]
+    index 1 + =: index
+  ] createDetachedLoop open
 
   amt
 ] @: amount
@@ -560,8 +609,7 @@
   $: b $: a
 
   a count dup
-  b count = not =>
-    [ 'counts must be equal with zip, otherwise see zipWithDefault' die ]
+  b count = not => [ 'counts must be equal with zip, otherwise use zipWithDefault' die ]
 
   [ ] $: result
 
@@ -617,8 +665,8 @@
 
 [ """( S D -- Di ): given a Source block and a Destination
    block, leaves an instance of Destination block with all
-   words (see `word?`) replaced with entry values from Table
-   source (they are **not** opened), and all quoted words
+   words (see `word?`) replaced with entry values from table
+   Source (they are **not** opened), and all quoted words
    unquoted (see `quotedWord?`). Recurses on sub-blocks.
 
   >>> 1 $: x  2 $: y  #+ $: plus
@@ -642,7 +690,7 @@
 [ """( B -- Bi ): `conjure` with Source block set to caller.
 
   >>> 1 $: x  2 $: y  #+ $: plus
-  >>> [ x y plus #dup plus [ ##foo #echo] #open ] here
+  >>> [ x y plus #dup plus [ ##foo #echo ] #open ] here
   === [ 1 2 + dup + [ #foo echo | ] #open | ]
   >>> open
   STDOUT: foo
@@ -776,17 +824,25 @@
 
 
 [ """( N B -- Lb ): leaves a List block with N results of opening
-   Block with the current N.
+   Block with the current N. `break` and `next` are available.
 
-  >>> 3 [ readLine [ ] [ drop 0 ] br ] collect
+  >>> 3 [ readLine [ stack swap slurp ] [ drop 0 ] br ] collect
   INPUT: 0 3
   INPUT: 1 5
   INPUT: 2 12
   === [ 3 5 12 ]
   """
-  @: block [ ] $: result
+  $: block $: max [ ] $: result
 
-  times: [ block result gulp ]
+  max negative? => [ 'collect: cannot have negative amount' die ]
+
+  0 $: current
+
+  block  [ current max < ]
+  [
+    current swap open result gulp
+    current 1 + =: current
+  ] createDetachedLoop open
 
   result
 ] @: collect

--- a/core/block.nk
+++ b/core/block.nk
@@ -330,7 +330,7 @@
 ] @: each:
 
 
-[ """( Lb each: B -- ): infix version of `eachWithIndex`.
+[ """( Lb eachWithIndex: B -- ): infix version of `eachWithIndex`.
 
   >>> [ 1 2 3 ] eachWithIndex: [ 2echo ]
   STDOUT: 0 1

--- a/core/flow.nk
+++ b/core/flow.nk
@@ -106,91 +106,103 @@
 ] @: ^
 
 
-[ "( B -- I ): injects `break` and `continue` into an Instance
-   of Block. `break` drops continuations until and including
-   the caller block, and `continue`, drops them up to and
-   including the Body block (and/or its instances)."
-    dup $: body
-    new $: instance
-  ahead $: caller
+[ "( Ib -- Sh Bh Ch ): takes an Iteration body block and leaves
+    three handles: one to Start the loop, one to Break the loop,
+    and one to next the loop."
+  $: iterBody
 
-  instance #break [ "( -- ): quits from the enclosing loop."
-    [ continuationBlock caller same? ] dropContinuationsUntil
-  ] opens
+  #nil $: breakTo
 
-  instance #continue [ "( -- ): quits from current loop iteration."
-    [ continuationBlock prototype body same? ] dropContinuationsUntil
-  ] opens
+  [ orphan iterBody hydrate repeat ] $: loopBody
 
-  instance
-] @: newWithBreakAndContinue
+  [ this =: breakTo orphan loopBody hydrate! ]
+  [  breakTo resume ]
+  [ loopBody resume ]
+] @: createLoop
 
 
-[ "( B -- ): basic infinite loop over Block. `break` and `continue`
-   are made available in Block. Block is opened in an empty stack."
-  newWithBreakAndContinue $: block
+[ "( Bb Ctb Cdb -- Sh ): defines `break` and `next` for a Body
+   block that is being evaluated indirectly by a Control block,
+   and only if the Condition block leaves a truthy value on top
+   of the stack it hydrated. `next` resumes the Control block."
+ $: ctrl $: cond new $: bodyInstance
 
-  [ orphan block hydrate repeat ] open
+  #nil $: ctrlNow
+
+  [ cond val
+      [ ctrl new =: ctrlNow bodyInstance enclose ctrlNow hydrate! ]
+      breakLoop
+    br
+  ] createLoop drop $: breakLoop @: startLoop
+
+  [ bodyInstance #break breakLoop opens
+    bodyInstance #next [ ctrlNow resume ] opens
+    startLoop ]
+] @: createDetachedLoop
+
+
+[ "( Ib -- ): basic infinite loop over an Iteration body block.
+   `break` and `next` are available in the block. A new
+   stack created for each iteration."
+  new $: iterBody
+
+  iterBody createLoop
+    $: nextLoop
+    $: breakLoop
+    @: startLoop
+
+  iterBody #break breakLoop opens
+  iterBody #next nextLoop opens
+
+  startLoop
 ] @: loop
 
 
-[ "( loop: B -- ): prefix version of `loop`. Has no difference
-   in regards to functionality."
+[ "( loop: Ib -- ): prefix version of `loop`."
   ahead eject loop
 ] @: loop:
 
 
-[ "( C B -- ): opens Condition in an empty stack, Body in a
-   new stack with Condition's result on top, all while Condition
-   top is truthy after it's opened. Similar to `loop`, words `break`
-   and `continue` are made available in Body."
-  newWithBreakAndContinue $: body $: condition
-
-  loop: [
-    condition val dup
-      [ enclose body hydrate ] "Condition truthy: enclose & proceed with body!"
-      [ drop break ]           "Condition falsey: drop the false and get out."
-    br
-  ]
+[ "( C B -- ): hydrates an empty stack with Condition; if ToS
+   is truthy afterwards, Block is opened over an empty stack.
+   Repeats until ToS is false. Similar to `loop`, words `break`
+   and `next` are available in Block."
+  swap [ open ] createDetachedLoop open
 ] @: while
 
 
-[ "( while: C B -- ): prefix version of `while`. Has no difference
-   in regards to functionality."
+[ "( while: C B -- ): prefix version of `while`."
   ahead eject
   ahead eject
   while
 ] @: while:
 
 
-[ "( C B -- ): inverse of `while` (opens Body while Condition
+[ "( C B -- ): inverse of `while` (opens Block while Condition
    is **false**), for more info see `while`."
-  $: body @: condition
-
-  [ condition not ] body while
+  <| shallowCopy #not << |> while
 ] @: until
 
 
-[ "( until: C B -- ): prefix version of `until`. Has no difference
-   in regards to functionality."
+[ "( until: C B -- ): prefix version of `until`."
   ahead eject
   ahead eject
   until
 ] @: until:
 
 
-[ "( N B -- ): opens Body N times. Body is opened in a new
-   stack with current N. `break` and `continue` available."
-  over negative? => [ 'times: cannot have negative N' die ]
+[ "( N B -- ): opens Block N times. Block is opened in a new
+   stack with current N. `break` and `next` available."
+  $: block $: max
 
-  newWithBreakAndContinue $: body $: stop
+  max negative? => [ 'times: cannot have negative bound' die ]
 
-  0 $: start
+  0 $: current
 
-  while: [ start stop < ] [
-    start enclose body hydrate
-    start 1 + =: start
-  ]
+  block
+  [ current max < ]
+  [ current swap open current 1 + =: current ]
+  createDetachedLoop open
 ] @: times
 
 

--- a/core/flow.nk
+++ b/core/flow.nk
@@ -199,10 +199,10 @@
 
   0 $: current
 
-  block
-  [ current max < ]
-  [ current swap open current 1 + =: current ]
-  createDetachedLoop open
+  block [ current max < ]
+  [
+    current swap open current 1 + =: current
+  ] createDetachedLoop open
 ] @: times
 
 

--- a/doc/novikas-approach-to-loops.md
+++ b/doc/novikas-approach-to-loops.md
@@ -112,8 +112,7 @@ The instantiation problem is solved by `loop`. Loop is the word you should use t
 really, forget about `repeat`.
 
 ```novika
-[ newWithBreakAndContinue $: block
-
+[ $: block
   [ orphan block hydrate repeat ] open
 ] @: loop
 ```

--- a/doc/novikas-approach-to-loops.md
+++ b/doc/novikas-approach-to-loops.md
@@ -1,0 +1,453 @@
+# Novika's approach to loops
+
+Loops are present in almost all programming languages; they make programming languages
+Turing-complete, and so fun to work with. They drive web servers, operating systems,
+interpreters such as Novika. Loops are the very heart of games and game programming.
+
+This document is a brief, technical overview of how Novika approaches loops.
+
+## Crystal
+
+Novika is written in Crystal. Even though you won't find a "looping primitive" in kernel
+or anywhere else, there still is a loop at the core of the interpreter which is accessible
+from Novika-land: the *interpreter loop* itself. In rev10, the interpreter loop has its
+own object -- a struct called `Engine`. You may see the interpreter loop being referred
+to as the *engine loop* or the *exhaust loop*. These all stand for the same thing.
+
+Here is what `Engine#exhaust` looks like, with error handling code omitted for it is in
+this case irrelevant:
+
+```crystal
+until conts.empty?
+  while form = block.next?
+    form.opened(self)
+  end
+  conts.drop
+end
+```
+
+We are interested in the implementation of `block.next?`, `Block#next?`:
+
+```crystal=
+def next? : Form?
+  self.tape, _ = tape.next? || return
+end
+```
+
+As you can see, it basically delegates the call to block's `Tape`. And since tape is passed
+by value, we need to overwrite the block's ivar, `@tape`, to make the changes known (here via
+the setter `tape=`).
+
+We don't need to go deeper than `Tape#next?` though; its code shows us all we'd want
+to know about `next?` that is not an implementation detail:
+
+```crystal=
+def next?
+  {Tape.new(substrate, cursor + 1), substrate.at!(cursor)} if cursor < count
+end
+```
+
+As you can see, first, the next (and resulting) tape is created that has its cursor advanced
+once. Then, the item at the current cursor position is fetched from the tape substrate. This
+makes the block's cursor slide to the right:
+
+```text
+[ | 1 2 3 ]
+----------- starting to call .next?
+[ 1 | 2 3 ]
+[ 1 2 | 3 ]
+[ 1 2 3 | ]
+```
+
+Actually, this is just what Novika's native `|slideRight` word does.
+
+## Novika
+
+Now let’s look at how Novika builds loops up from what’s described above.
+
+### `repeat`
+
+The basic looping primitive is called `repeat`. All it does is it sets the opener block's cursor
+to 0. Therefore, after `repeat` is opened, `while form = block.next?` will start opening forms
+at the beginning of the block again.
+
+```novika
+[ ahead 0 |to ] @: repeat
+```
+
+Note that no one forces you to use `repeat`. You could easily replace it in-place with `this 0 |to`.
+Neither is it necessary to use `this` or `ahead`: you can apply `0 |to` to any block that is on the
+continuations stack (to any block really, but to make it a loop and not just a block with cursor at 0
+you'd want that block to be on the continuations stack).
+
+That said, using `repeat` is a convention, mainly for hiding the underlying engine loop abuse.
+
+Note that if `repeat` is reachable at all times, the loop will be infinite:
+
+```novika
+'To infinity and beyond!' echo repeat
+```
+
+You can think of `repeat` as a recursive call to the current block, but instead of growing the call
+stack it replaces the pivot entry. In that it is similar to tail call. *Think of* is not *is* though,
+beware. There are no tail calls anywhere.
+
+**But not all is so simple.** There are two problems with `repeat`.
+
+First, it doesn't re-instantiate the opener block. Same for `this 0 |at`, etc. `ahead eject` and friends
+make their opener block dirty; that's one of the reasons we instantiate blocks upon opening in the first
+place, and that's something we would want to hide from the final user for as long as possible and as
+quickly as possible. If you open the same instance again, you may see a few forms missing (e.g., `$: foo`
+will become just `$:`, because `$:` consumes (`ahead eject`s) the word that follows), or a few forms
+which were not present in the prototype block.
+
+Second, `repeat`, `this 0 |to`, etc. apply just to the current block, or to a block at a particular depth
+only. E.g., you can't use them in a branch block to repeat the block that contains the branch; only the
+branch block will be repeated. Either you'd need to exit earlier than you repeat, e.g., via `^`, or keep
+a reference to the loop block and `0 |at` it when necessary.
+
+### `loop`
+
+The instantiation problem is solved by `loop`. Loop is the word you should use to make your loops. So
+really, forget about `repeat`.
+
+```novika
+[ newWithBreakAndContinue $: block
+
+  [ orphan block hydrate repeat ] open
+] @: loop
+```
+
+For each iteration of the loop, a new empty stack is created by `orphan`. It is then packed together
+with an instance of the iteration block into a continuation block by `hydrate`, and pushed onto the
+continuations stack.
+
+`orphan` takes care of creating a new empty block per each iteration, for the iteration stack.
+
+`hydrate` takes care of creating an instance of iteration block per each iteration, for the iteration
+block. Now, thanks to `loop`, the body block aka iteration block is instantiated as one would expect.
+
+### Controlling `loop`s
+
+Having an infinite loop is cool, but sometimes (almost always, actually) we need to stop looping,
+or re-evaluate the loop body block.
+
+#### Closing (breaking) a loop
+
+One way to close a loop is to use `^`, but you'd have to make a little dance for that to work
+properly, because you can also next the loop using `^`, or do nothing about the loop at all,
+still with `^`.
+
+`^` closes blocks all the way up to, and including, its *opener's parent*. In this code excerpt:
+
+```novika
+'Hey!' echo
+
+[
+  [
+    'Aw!' echo
+    ^
+  ] loop
+] open
+
+'Bye!' echo
+```
+
+... the opener of `^` is the block `[ 'Aw!' echo ^ ]`. Its parent is the block `[ [ … ] loop ]`.
+If we close it, we get to `[ 'Hey!' echo [ … ] open | 'Bye!' echo ]` (you can even see the `open`).
+
+```text
+Hey!
+Aw!
+Bye!
+```
+
+As you can see, the loop was closed successfully since `Aw!` was printed only once.
+
+#### Continuing loops
+
+To next a loop means to close the current iteration block, so the loop definition
+(the one with `hydrate` and `repeat`, see above) can re-open it again. If you want to
+use `^` for that, you'll need to have a nested block in `loop` and open `^` there:
+
+```novika
+[
+  'A' echo
+  [ ^ ] open
+  'B' echo
+] loop
+```
+
+... will print `A` for eternity.
+
+#### How this looks in practice
+
+If `[ ^ ]` continues body, then `=> [ ^ ]` continues the body too, i.e., you can *conditionally*
+continue looping, and exit otherwise.
+
+Here is a `loop` that will print numbers from 0 to 100.
+
+```novika
+0 $: n
+
+[
+  [
+    n 100 < => [
+      n echo
+      n 1 + =: n
+      ^ "(aka next)"
+    ]
+    ^ "(aka break)"
+  ] loop
+] open
+```
+
+We have to wrap it in `[ … ] open` because there's no block above the toplevel block, and so the
+last `^` won't have any block to break out to and will crash the engine (because of continuations
+stack underflow, if you're interested).
+
+### Alternative control: implementing `break` and `next` for `loop`
+
+Instead of torturing the user with `^` and its semantics and providing nothing but `loop`, Novika
+implements call-depth-independent `break` and `next`, which are known by virtually all programmers
+to do the following: `break` closes the loop that is its nearmost surrounding (aka deepest), and
+`next` closes the loop iteration block of the loop that is its nearmost surrounding (aka deepest).
+
+In order to implement these two words, `resume` comes very handy. It drops all continuations until
+one that has the specified block as its continuation block. Here is how we could implement the
+example above, now with the help of `resume`:
+
+```novika
+this $: blockToBreakTo
+0 $: n
+
+[
+  ahead $: continueBlock
+
+  n 100 < => [
+    n echo
+    n 1 + =: n
+    continueBlock resume
+  ]
+  blockToBreakTo resume
+] loop
+
+'Bye!' echo
+```
+
+This piece of code still looks very weird, but it is just a small step toward `break` and `next`.
+Thanks to `resume`, we can now set next-points programmatically.
+
+#### `createLoop`
+
+The next small step is `createLoop`. It takes an iteration body block and leaves three blocks: one
+to start the loop, one to end the loop (to *break* it), and one to end current iteration (to *next* it).
+
+```novika
+[ $: iterBody
+
+  #nil $: breakTo
+
+ [ orphan iterBody hydrate repeat ] $: loopBody
+
+ "Start loop:" [ this =: breakTo orphan loopBody hydrate! ]
+ "Break loop:" [  breakTo resume ]
+   "Continue:" [ loopBody resume ]
+] @: createLoop
+```
+
+#### `loop`
+
+Now it's easy to define `loop`, one that is much more user-friendly in terms of control.
+
+```novika
+[ new $: iterBody
+
+  iterBody createLoop
+    $: continueLoop
+    $: breakLoop
+    @: startLoop
+
+  iterBody #break breakLoop opens
+  iterBody #next continueLoop opens
+
+  startLoop
+] @: loop
+```
+
+This code creates a loop for an instance of the iteration body block it is given,
+assigns the break and next handles `createLoop` leaves to the corresponding entries
+in `iterBody`, and opens the `startLoop` handle. The latter starts looping immediately.
+
+```novika
+0 $: n
+
+[
+  n echo
+  n 100 = => [ break ]
+  n 1 + =: n
+] loop
+```
+
+`next` also works. Let's write the famous fizz-buzz program:
+
+```novika
+1 $: n
+
+[
+  n 100 > => [ break ]
+
+  n 15 /? => [ 'FizzBuzz' echo n 1 + =: n next ]
+  n 5  /? => [     'Buzz' echo n 1 + =: n next ]
+  n 3  /? => [     'Fizz' echo n 1 + =: n next ]
+
+  n echo n 1 + =: n
+] loop
+```
+
+Obviously there is some repetition that can be trivially eliminated, but this example is here
+to demonstrate `next` and `break` (they could disappear if we start cleaning up the code).
+
+#### `createDetachedLoop`
+
+An important step towards having `while`, `until`, and more high-level looping constructs,
+is `createDetachedLoop`, which defines `break` and `next` for a body block that is being
+evaluated indirectly by a control block, and only if the condition block leaves a truthy
+value on top of the stack it hydrated. `next` now resumes the control block instead of
+the iteration body block.
+
+```novika
+[ $: ctrl $: cond new $: bodyInstance
+
+  #nil $: ctrlNow
+
+  [ cond val
+      [ ctrl new =: ctrlNow
+        bodyInstance enclose ctrlNow hydrate! ]
+      breakLoop
+    br
+  ] createLoop drop $: breakLoop @: startLoop
+
+  [
+    bodyInstance #break breakLoop opens
+    bodyInstance #next [ ctrlNow resume ] opens
+    startLoop
+  ]
+] @: createDetachedLoop
+```
+
+#### `while`
+
+Now that we have `createDetachedLoop`, we can implement `while`.
+
+```novika
+[ swap [ open ] createDetachedLoop open ] @: while
+```
+
+#### `until`
+
+Until is the inverse of while (or while is the inverse of until). Here we just append
+`not` to the condition. Since the condition block doesn't really expect anything to be
+appended into it, we make a shallow copy of it.
+
+```novika
+[ <| shallowCopy #not << |> while ] @: until
+```
+
+#### `times`
+
+`times` is the first high-level looping word Novika implements. It repeats the block
+it is given a certain amount of times. We have previously made a loop which counts up.
+Our sole purpose is to generalize that, and to expose `break` and `next` to the user's
+body block. `createDetachedLoop` helps us do all of this.
+
+```novika
+[ swap $: max 0 $: n
+
+  [ n max < ] [ n swap open n 1 + =: n ] createDetachedLoop open
+] @: times
+```
+
+`break` and `next` are available to the body:
+
+```novika
+100 [
+  dup 50 < => [ next ]
+  dup 2 /? => [ next ]
+  dup 80 > => [ break ]
+  echo
+] times
+```
+
+The code above outputs all odd numbers in the range `50 < n <= 80`:
+
+```text
+51
+53
+55
+57
+59
+61
+63
+65
+67
+69
+71
+73
+75
+77
+79
+```
+
+Novika also implements `times:`, which makes it look a bit more readable:
+
+```
+100 times: [
+  dup 50 < => [ next ]
+  dup 2 /? => [ next ]
+  dup 80 > => [ break ]
+  echo
+]
+```
+
+#### `|slideRight`
+
+`|slideRight` is easily implemented via `createDetachedLoop`. One difference from `times`
+is that the maximum bound is the size of the block it's iterating over; it's dynamic and
+must be recomputed every time.
+
+```novika
+[ $: body $: list
+
+  body
+  [ list dup |at over count < ]
+  [ list dup |at 1 + |to
+    list swap hydrate ]
+
+  createDetachedLoop open
+] @: |slideRight
+```
+
+#### `each`
+
+`createDetachedLoop` can be used again. There is little point in using `each` when you have
+`|slideRight`, but sometimes it may be preferred for purity or performance.
+
+```
+[ $: body $: list 0 $: index
+
+  body
+  [ index list count < ]
+  [
+     list index fromLeft enclose swap hydrate
+     index 1 + =: index
+  ] createDetachedLoop open
+] @: each
+```
+
+#### And so on
+
+This article ends here but Novika's high-level looping doesn't. Look into `core/block.nk`
+for more looping vocabulary, like `collect`, `zipWithDefault`, and more. Most of them use
+`createDetachedLoop` in one way or another, mainly to allow the user to `break` and `next`.
+

--- a/doc/novikas-approach-to-loops.md
+++ b/doc/novikas-approach-to-loops.md
@@ -28,7 +28,7 @@ end
 
 We are interested in the implementation of `block.next?`, `Block#next?`:
 
-```crystal=
+```crystal
 def next? : Form?
   self.tape, _ = tape.next? || return
 end
@@ -41,7 +41,7 @@ the setter `tape=`).
 We don't need to go deeper than `Tape#next?` though; its code shows us all we'd want
 to know about `next?` that is not an implementation detail:
 
-```crystal=
+```crystal
 def next?
   {Tape.new(substrate, cursor + 1), substrate.at!(cursor)} if cursor < count
 end

--- a/tests/block.nk
+++ b/tests/block.nk
@@ -235,13 +235,13 @@ describe 'fetch:' [
   it should 'ignore non-block forms' [
     'This is not a block!' #x fetch: [ 1 + ]
 
-    stack empty? true assert=
+    stack empty?
   ]
 
   it should 'do nothing when entry does not exist' [
     [ ] #x fetch: [ 1 + ]
 
-    stack empty? true assert=
+    stack empty?
   ]
 
   it should 'fetch when entry exists' [
@@ -272,7 +272,7 @@ describe 'fetch:' [
 
 describe '|slideRight' [
   it should 'do nothing if empty list block' [
-    [ ] [ 1 + ] |slideRight
+    [ ] [ 1 + ] |slideRight [ ] assert=
   ]
 
   it should 'modify the original block' [
@@ -352,7 +352,7 @@ describe '|slideRight' [
 
 describe '|slideLeft' [
   it should 'do nothing if empty list block' [
-    [ ] [ 1 + ] |slideLeft
+    [ ] [ 1 + ] |slideLeft [ ] assert=
   ]
 
   it should 'modify the original block' [
@@ -411,7 +411,7 @@ describe 'eachWithIndex' [
   it should 'do nothing if empty list block' [
     [ ] eachWithIndex: [ 1 + ]
 
-    true
+    stack empty?
   ]
 
   it should 'iterate over whole block with cursor at end' [
@@ -471,7 +471,7 @@ describe 'each' [
   it should 'do nothing if empty list block' [
     [ ] each: [ 1 + ]
 
-    true
+    stack empty?
   ]
 
   it should 'iterate over whole block with cursor at end' [
@@ -525,19 +525,31 @@ describe 'pairs' [
   it should 'do nothing if list block is empty' [
     [ ] pairs: [ + ]
 
-    true
+    stack empty?
   ]
 
   it dies 'when count is odd' [
     [ 1 2 3 ] pairs: [ + ]
   ]
 
-
   it should 'call action block with each pair as stack' [
     [ ] $: stacks
 
     [ 1 2 3 4 ] pairs: [ stacks stack shove ]
 
+    stacks [
+      [ 1 2 ]
+      [ 3 4 ]
+    ] assert=
+  ]
+
+  it should 'leave cursor intact' [
+    [ ] $: stacks
+
+    [ 1 2 3 4 ] $: a
+    a 2 |to
+    a pairs: [ stacks stack shove ]
+    a |at 2 assert=
     stacks [
       [ 1 2 ]
       [ 3 4 ]
@@ -562,5 +574,128 @@ describe 'pairs' [
     ]
 
     visited [ [ 1 2 ] 0 0 ] assert=
+  ]
+]
+
+describe 'consPairs' [
+  it should 'do nothing if list block is empty' [
+    [ ] consPairs: [ + ]
+
+    stack empty?
+  ]
+
+  it should 'do nothing if one item in list block' [
+    [ 1 ] consPairs: [ + ]
+
+    stack empty?
+  ]
+
+  it should 'leave cursor intact' [
+    [ ] $: stacks
+    [ 1 2 3 4 ] $: a
+    a 2 |to
+    a consPairs: [ stacks stack shove ]
+    a |at 2 assert=
+    stacks [
+      [ 1 2 ]
+      [ 2 3 ]
+      [ 3 4 ]
+    ] assert=
+  ]
+
+  it should 'support even number of items' [
+    [ ] $: items
+    [ 1 2 3 4 ] consPairs: [ + items gulp ]
+    items [ 3 5 7 ] assert=
+  ]
+
+  it should 'support odd number of items' [
+    [ ] $: items
+    [ 1 2 3 ] consPairs: [ + items gulp ]
+    items [ 3 5 ] assert=
+  ]
+
+  it should 'support next and break' [
+      [ ] $: items
+    false $: went
+
+    [ 1 2 3 4 5 6 ] consPairs: [
+      2dup * 10 > => [ break ]
+      + items gulp
+      next
+      true =: went
+    ]
+
+    items [ 3 5 ] assert=
+    went false assert=
+  ]
+]
+
+describe 'map' [
+  it should 'do nothing if list block is empty' [
+    [ ] map: [ 1 + ] [ ] assert=
+  ]
+
+  it should 'not change original block' [
+    [ 1 2 3 ] $: a
+    a map: [ 1 + ] [ 2 3 4 ] assert=
+    a [ 1 2 3 ] assert=
+  ]
+
+  it should 'leave cursor intact' [
+    [ 1 2 3 ] $: a
+    a 1 |to
+    a map: [ 1 + ] [ 2 3 4 ] assert=
+    a |at 1 assert=
+  ]
+
+  it should 'support break and next where next means don`t keep if stack empty' [
+    [ 1 101 2 3 200 4 1000 5 1001 2 3 ] $: a
+    a map: [ $: n
+      n 1000 > => [ break ]
+      n 100 > => [ next ]
+      n 1 +
+    ] [ 2 3 4 5 6 ] assert=
+  ]
+]
+
+describe 'only' [
+  it should 'do nothing if list block is empty' [
+    [ ] [ 100 > ] only [ ] assert=
+  ]
+
+  it should 'keep if action block is empty' [
+    [ 1 2 3 ] [ ] only [ 1 2 3 ] assert=
+  ]
+
+  it should 'select values for which action block leaves truthy' [
+    [ 1 100 2 300 4 600 10 ] only: [ 100 > ] [ 300 600 ] assert=
+  ]
+
+  it should 'reject values for which action block leaves false' [
+    [ 1 100 2 300 4 600 10 ] only: [ false ] [ ] assert=
+  ]
+
+  it should 'not modify original block' [
+    [ 1 2 3 ] $: a
+    a only: [ 1 > ] $: b
+    b [ 2 3 ] assert=
+    a [ 1 2 3 ] assert=
+  ]
+
+  it should 'leave cursor intact' [
+    [ 1 2 3 ] $: a
+    a 1 |to
+    a only: [ 1 > ] [ 2 3 ] assert=
+    a |at 1 assert=
+  ]
+
+  it should 'support next & break where next means don`t keep if stack empty' [
+    [ 1 101 2 3 200 4 1000 5 1001 2 3 ] $: a
+    a only: [ $: n
+      n 1000 > => [ break ]
+      n 100 > => [ next ]
+      n 1 + 4 <=
+    ] [ 1 2 3 ] assert=
   ]
 ]

--- a/tests/block.nk
+++ b/tests/block.nk
@@ -699,3 +699,250 @@ describe 'only' [
     ] [ 1 2 3 ] assert=
   ]
 ]
+
+describe 'reduce' [
+  it should 'leave memo if list block is empty' [
+    [ ] [ + ] 0 reduce 0 assert=
+  ]
+
+  it should 'call block for one value' [
+    false $: status
+    [ 1 ] [ true =: status + ] 0 reduce 1 assert=
+    status
+  ]
+
+  it should 'call block and reduce multiple values' [
+    [ 1 2 3 4 5 ] [ * ] 1 reduce 120 assert=
+    [ 'Hellope, ' 'Europe!' ' ' 'Huh?' ] [ stitch ] '' reduce 'Hellope, Europe! Huh?' assert=
+  ]
+
+  it should 'support next' [
+    [ 1 2 3 4 5 ] [ dup odd? => [ drop "memo left here" next ] + ] 0 reduce 6 assert=
+  ]
+
+  it should 'support break' [
+    [ 1 1 7 3 2 3 4 5 ] [ dup even? => [ break ] + ] 0 reduce 12 assert=
+  ]
+]
+
+describe 'amount' [
+  it should 'leave zero for empty block' [
+    [ ] # [ even? ] 0 assert=
+  ]
+
+  it should 'provide proper stack to action block' [
+    [ ] $: stacks
+    [ 1 2 3 4 ] # [ stack shallowCopy stacks gulp ] 4 assert=
+    stacks [ [ 1 ] [ 2 ] [ 3 ] [ 4 ] ] assert=
+  ]
+
+  it should 'count all with empty action block' [
+    [ 1 2 3 ] # [ ] 3 assert=
+  ]
+
+  it should 'support single item list' [
+    [ 1 ] # [ even? ] 0 assert=
+    [ 4 ] # [ even? ] 1 assert=
+  ]
+
+  it should 'support multi item list' [
+    [ 1 2 3 4 ] # [ even? ] 2 assert=
+  ]
+
+  it should 'support break and next' [
+    [ 1 2 3 4 5 3 foo 5 6 7 8 ] # [ $: n
+      n #foo = => [ break ]
+      n even?  => [ false next ]
+      n 1 + 3 >
+    ] 3 assert=
+  ]
+]
+
+describe 'all?' [
+  it should 'leave true for empty list' [
+    [ ] [ ] all?
+  ]
+
+  it should 'leave true for empty action block' [
+    [ 1 2 3 ] [ ] all?
+  ]
+
+  it should 'leave proper result' [
+    [ 1 2 3 4 ] [ even? ] all? false assert=
+    [ 2 4 6 8 ] [ even? ] all? true assert=
+    [ 101 2 3 4 ] [ 100 < ] all? false assert=
+  ]
+
+  it dies 'when using next' [
+    [ 1 2 3 4 ] [ next ] all?
+  ]
+
+  it dies 'when using break' [
+    [ 1 2 3 4 ] [ break ] all?
+  ]
+]
+
+describe 'any?' [
+  it should 'leave false for empty list' [
+    [ ] [ ] any? not
+  ]
+
+  it should 'leave true for empty action block' [
+    [ 1 2 3 ] [ ] any?
+  ]
+
+  it should 'leave proper result' [
+    [ 1 2 3 4 ] [ even? ] any? true assert=
+    [ 2 4 6 8 ] [ odd? ] any? false assert=
+    [ 101 2 3 4 ] [ 100 < ] any? true assert=
+  ]
+
+  it dies 'when using next' [
+    [ 1 2 3 4 ] [ next ] any?
+  ]
+
+  it dies 'when using break' [
+    [ 1 2 3 4 ] [ break ] any?
+  ]
+]
+
+describe 'zip' [
+  it should 'zip two empty blocks into an empty block' [
+    [ ] [ ] zip [ ] assert=
+  ]
+
+  it should 'zip with equal amount of items' [
+    [ 1 ] [ 2 ] zip [ [ 1 2 ] ] assert=
+    [ 1 2 ] [ 3 4 ]  zip [ [ 1 3 ] [ 2 4 ] ] assert=
+    [ 1 2 3 ] [ 3 4 5 ] zip  [ [ 1 3 ] [ 2 4 ] [ 3 5 ] ] assert=
+  ]
+
+
+  it dies 'when zipping with unequal amount of items (holes)' [
+    [ 1 2 ] [ 3 ] zip
+  ]
+]
+
+describe 'zipWithDefault' [
+  it should 'work for empty blocks' [
+    [ ] [ ] #hole zipWithDefault [ ] assert=
+  ]
+
+  it should 'work when there are no holes' [
+    [ 1 2 ] [ 3 4 ] #hole zipWithDefault [ [ 1 3 ] [ 2 4 ] ] assert=
+  ]
+
+  it should 'work when there are holes on the right' [
+    [ 1 2 ] [ 3 ] #hole zipWithDefault [ [ 1 3 ] [ 2 hole ] ] assert=
+  ]
+
+  it should 'work when there are holes on the right' [
+    [ 1 ] [ 3 4 ] #hole zipWithDefault [ [ 1 3 ] [ hole 4 ] ] assert=
+  ]
+
+  it should 'work with either list empty' [
+    [ ] [ 1 2 ] #hole zipWithDefault [ [ hole 1 ] [ hole 2 ] ] assert=
+    [ 1 2 ] [ ] #hole zipWithDefault [ [ 1 hole ] [ 2 hole ] ] assert=
+  ]
+]
+
+describe 'conjure/here' [
+  it should 'accept decimal, bool, etc.' [
+    0 here 0 assert=
+    true here true assert=
+    'hello' here 'hello' assert=
+  ]
+
+  it should 'leave definitions of words' [
+    [ 1 2 3 4 ] $: a
+    a $: b
+    #b here a same?
+  ]
+
+  it should 'peel off a # from quoted words' [
+    ###foo here ##foo assert=
+    ##foo here #foo assert=
+  ]
+
+  it should 'recurse into blocks' [
+    0 $: a
+    1 $: b
+    2 $: c
+    3 $: d
+
+    [ [ [ [ a 'foo' ] b 1 ] c 'bar' d ] #baz ] here
+    [ [ [ [ 0 'foo' ] 1 1 ] 2 'bar' 3 ]  baz ]
+    assert=
+  ]
+
+  it dies 'on undefined words' [
+    foo here
+  ]
+
+  it should 'trigger word trap when word is undefined' [
+    [ enquote 2 sliceQuoteAt nip ] @: *trap
+    foobar here 'oobar' assert=
+  ]
+]
+
+describe 'minmax' [
+  it dies 'when block is empty' [
+    [ ] minmax
+  ]
+
+  it dies 'when items are not decimals' [
+    [ foo ] minmax
+  ]
+
+  it should 'leave same result when block is count 1' [
+    [ 100 ] minmax stack shallowCopy [ 100 100 ] assert=
+  ]
+
+  it should 'leave proper result for > 1 items in block' [
+    [ 100 200 5 300 405 ] minmax stack shallowCopy [ 5 405 ] assert=
+  ]
+
+  it should 'handle blocks which implement *asDecimal' [
+    [ -101 $: *asDecimal this ] open $: a
+    [ 500 $: *asDecimal this ] open $: b
+
+    "There is no good way to do this right now unfortunately..."
+    [ -100 100 ] [ <| a |> b ] there
+
+    minmax
+
+    "Note how minmax still returns a, b, not their numeric values.
+     I don't know whether this is what's expected."
+    stack shallowCopy a b 2enclose assert=
+  ]
+]
+
+"Min, max are (or could be, if certain behavior is desired) implemented
+ via `minmax` and don't require testing here."
+
+describe 'sum' [
+  it should 'leave 0 when block is empty' [
+    [ ] sum 0 assert=
+  ]
+
+  it should 'leave number when block has one number' [
+    [ 100 ] sum 100 assert=
+  ]
+
+  it should 'leave sum otherwise' [
+    [ 100 200 300 ] sum 600 assert=
+  ]
+
+  it should 'support blocks implementing *asDecimal' [
+    [ $: n [ n 1 + ] @: *asDecimal this ] @: foos
+
+    100 foos "101"
+    200 foos "201"
+    2enclose
+
+    300 foos "301"
+    <<
+
+    sum 603 assert=
+  ]
+]

--- a/tests/block.nk
+++ b/tests/block.nk
@@ -407,3 +407,116 @@ describe '|slideLeft' [
   ]
 ]
 
+describe 'eachWithIndex' [
+  it should 'do nothing if empty list block' [
+    [ ] eachWithIndex: [ 1 + ]
+
+    true
+  ]
+
+  it should 'iterate over whole block with cursor at end' [
+    [ ] $: items [ ] $: indices
+
+    [ 2 3 4 ] eachWithIndex: [ items gulp indices gulp ]
+
+    [ 2 3 4 ] items   assert=
+    [ 0 1 2 ] indices assert=
+  ]
+
+  it should 'iterate over whole block with cursor at start' [
+    [ ] $: items [ ] $: indices
+
+    [ 2 3 4 ] dup 0 |to eachWithIndex: [ items gulp indices gulp ]
+
+    [ 2 3 4 ] items   assert=
+    [ 0 1 2 ] indices assert=
+  ]
+
+  it should 'iterate over whole block with cursor anywhere else' [
+    [ ] $: items [ ] $: indices
+
+    [ 2 3 4 ] dup 1 |to eachWithIndex: [ items gulp indices gulp ]
+
+    [ 2 3 4 ] items   assert=
+    [ 0 1 2 ] indices assert=
+  ]
+
+  it should 'leave cursor intact' [
+    [ 2 3 4 ] $: a
+    a 1 |to
+    a eachWithIndex: [ ]
+    a |at 1 assert=
+  ]
+
+  it should 'not modify block &/ with leftovers' [
+    [ 2 3 4 ] $: a
+    a eachWithIndex: [ 1 + 100 ]
+    a [ 2 3 4 ] assert=
+  ]
+
+  it should 'support next and break' [
+    [ ] $: items
+
+    [ 2 7 8 7 1 9 3 4 5 6 ] eachWithIndex: [ $: item $: index
+      item even? => [ next ]
+      item 3 /?  => [ break ]
+      items index item 2enclose shove
+    ]
+
+    items [ [ 1 7 ] [ 3 7 ] [ 4 1 ] ] assert=
+  ]
+]
+
+describe 'each' [
+  it should 'do nothing if empty list block' [
+    [ ] each: [ 1 + ]
+
+    true
+  ]
+
+  it should 'iterate over whole block with cursor at end' [
+    [ ] $: items
+
+    [ 2 3 4 ] each: [ items gulp ]
+    [ 2 3 4 ] items assert=
+  ]
+
+  it should 'iterate over whole block with cursor at start' [
+    [ ] $: items
+
+    [ 2 3 4 ] dup 0 |to each: [ items gulp ]
+    [ 2 3 4 ] items assert=
+  ]
+
+  it should 'iterate over whole block with cursor anywhere else' [
+    [ ] $: items
+
+    [ 2 3 4 ] dup 1 |to each: [ items gulp ]
+    [ 2 3 4 ] items assert=
+  ]
+
+  it should 'leave cursor intact' [
+    [ 2 3 4 ] $: a
+    a 1 |to
+    a each: [ ]
+    a |at 1 assert=
+  ]
+
+  it should 'not modify block &/ with leftovers' [
+    [ 2 3 4 ] $: a
+    a each: [ 1 + 100 ]
+    a [ 2 3 4 ] assert=
+  ]
+
+  it should 'support next and break' [
+    [ ] $: items
+
+    [ 2 7 8 7 1 9 3 4 5 6 ] each: [ $: item
+      item even? => [ next ]
+      item 3 /?  => [ break ]
+      items item shove
+    ]
+
+    items [ 7 7 1 ] assert=
+  ]
+]

--- a/tests/block.nk
+++ b/tests/block.nk
@@ -55,7 +55,7 @@ describe 'gulp' [
 
   it should 'add at cursor' [
     [ 1 2 3 ] $: block
-    
+
     block 2 |to
 
     #foo block gulp block [ 1 2 foo 3 ] dup 3 |to assert=
@@ -75,14 +75,14 @@ describe 'spit' [
 
   it should 'drop at cursor' [
     [ 1 2 3 ] $: block
-    
+
     block 2 |to
     block spit 2enclose 2 [ 1 3 ] dup 1 |to 2enclose assert=
   ]
 
   it should 'add at end' [
     [ 1 2 3 ] $: block
-    
+
     block spit 2enclose [ 3 [ 1 2 ] ] assert=
   ]
 ]
@@ -535,7 +535,7 @@ describe 'pairs' [
   it should 'call action block with each pair as stack' [
     [ ] $: stacks
 
-    [ 1 2 3 4 ] pairs: [ stacks stack shove ]
+    [ 1 2 3 4 ] pairs: [ stack shallowCopy stacks gulp ]
 
     stacks [
       [ 1 2 ]
@@ -548,7 +548,7 @@ describe 'pairs' [
 
     [ 1 2 3 4 ] $: a
     a 2 |to
-    a pairs: [ stacks stack shove ]
+    a pairs: [ stack shallowCopy stacks gulp ]
     a |at 2 assert=
     stacks [
       [ 1 2 ]
@@ -594,7 +594,7 @@ describe 'consPairs' [
     [ ] $: stacks
     [ 1 2 3 4 ] $: a
     a 2 |to
-    a consPairs: [ stacks stack shove ]
+    a consPairs: [ stack shallowCopy stacks gulp ]
     a |at 2 assert=
     stacks [
       [ 1 2 ]

--- a/tests/block.nk
+++ b/tests/block.nk
@@ -254,7 +254,7 @@ describe 'fetch:' [
     block #y fetch: [ =: yVal ]
 
     xVal 100 assert=
-    yVal 200 assert=    
+    yVal 200 assert=
   ]
 
   it should 'not evaluate openers' [
@@ -269,3 +269,141 @@ describe 'fetch:' [
     and
   ]
 ]
+
+describe '|slideRight' [
+  it should 'do nothing if empty list block' [
+    [ ] [ 1 + ] |slideRight
+  ]
+
+  it should 'modify the original block' [
+    [ 1 2 3 ] dup 0 |to $: a
+    a [ 1 + ] |slideRight a same? true assert=
+    a [ 2 3 4 ] assert=
+  ]
+
+  it should 'start at cursor' [
+    [ 1 2 3 ] dup 1 |to [ 1 + ] |slideRight [ 1 3 4 ] assert=
+  ]
+
+  it should 'handle insertion before' [
+    [ 1 2 3 ] dup 1 |to [ #boo swap 1 + ] |slideRight
+    [ 1 boo 3 boo 4 ] assert=
+  ]
+
+  it should 'handle insertion after' [
+    [ 1 2 3 ] dup 1 |to [ 1 + #boo ] |slideRight
+    [ 1 3 boo 4 boo ] assert=
+  ]
+
+  it should 'handle deletion' [
+    [ 1 2 3 ] dup 0 |to [ drop ] |slideRight [ ] assert=
+  ]
+
+  it should 'work with multiple items' [
+    [ 1 2 3 ] dup 1 |to [ + ] |slideRight [ 6 ] assert=
+  ]
+
+  it should 'support cursor movement' [
+    [ 1 2 3 ] dup 0 |to [ <| 'Hi!' |> ] |slideRight
+    [ 'Hi!' 1 'Hi!' 2 'Hi!' 3 ] assert=
+  ]
+
+  it should 'support reusing results from old iterations' [
+    "Add sum of previous elements to the current element."
+    [ 3 4 5 6 ] dup 1 |to [ over + ] |slideRight [ 3 7 12 18 ] assert=
+  ]
+
+  it should 'support next' [
+    [ 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 ] $: numbers
+
+    numbers 0 |to
+    numbers |-> [
+      dup 15 /?  => [ drop 'FizzBuzz' next ]
+      dup  5 /?  => [ drop 'Buzz' next ]
+      dup  3 /?  => [ drop 'Fizz' next ]
+      enquote
+    ]
+
+    [ '1' '2' 'Fizz' '4' 'Buzz' 'Fizz' '7' '8' 'Fizz' 'Buzz' '11' 'Fizz'
+      '13' '14' 'FizzBuzz' '16' '17' 'Fizz' '19' 'Buzz' 'Fizz' '22' '23'
+      'Fizz'  'Buzz' ]
+
+    assert=
+  ]
+
+  it should 'support break' [
+    [ 1 2 3 4 5 6 7 8 ] $: numbers
+
+    numbers 0 |to
+    numbers |-> [
+      dup 5 > => [ break ]
+      100 +
+    ]
+
+    "As you can see, break leaves the cursor AFTER the item
+     that failed to match."
+    [ 101 102 103 104 105 6 "|" 7 8 ] dup 6 |to assert=
+  ]
+
+  it dies 'upon underflow' [
+    [ 1 2 3 ] dup 0 |to [ swap ] |slideRight
+  ]
+]
+
+describe '|slideLeft' [
+  it should 'do nothing if empty list block' [
+    [ ] [ 1 + ] |slideLeft
+  ]
+
+  it should 'modify the original block' [
+    [ 1 2 3 ] $: a
+    a [ 1 + ] |slideLeft a same? true assert=
+    a [ 2 3 4 ] dup 0 |to assert=
+  ]
+
+  it should 'start at cursor' [
+    [ 1 2 3 ] dup 2 |to [ 1 + ] |slideLeft [ 2 3 3 ] dup 0 |to assert=
+  ]
+
+  it should 'handle insertion before' [
+    [ 1 2 3 ] dup 2 |to [ #boo #foo rot 1 + ] |slideLeft
+    [ boo foo 2 boo foo 3 3 ] dup 0 |to assert=
+  ]
+
+  it should 'handle insertion after' [
+    [ 1 2 3 ] dup 2 |to [ 1 + #boo ] |slideLeft
+    [ 2 boo 3 boo 3 ] dup 0 |to assert=
+  ]
+
+  it should 'handle deletion' [
+    [ 1 2 3 ] [ drop ] |slideLeft [ ] assert=
+  ]
+
+  it should 'work with multiple items & support break' [
+    [ 1 2 3 ] [ stack |at 1 = => [ break ] + ] |slideLeft [ 6 ] assert=
+  ]
+
+  it should 'support cursor movement' [
+    [ 1 2 3 ] [ <| 'Hi!' |> ] |slideLeft
+    [ 'Hi!' 1 'Hi!' 2 'Hi!' 3 ] dup 0 |to assert=
+  ]
+
+  it should 'support next' [
+    [ 1 2 3 4 5 ] <-| [
+      dup 3 > => [ next ]
+      1 +
+    ] [ 2 3 4 4 5 ] dup 0 |to assert=
+  ]
+
+  it should 'support break' [
+    [ 1 2 3 4 5 ] <-| [
+      dup 3 < => [ break ]
+      1 +
+    ] [ 1 2 "|" 4 5 6 ] dup 2 |to assert=
+  ]
+
+  it dies 'upon underflow' [
+    [ 1 2 3 ] [ swap ] |slideLeft
+  ]
+]
+

--- a/tests/block.nk
+++ b/tests/block.nk
@@ -917,8 +917,17 @@ describe 'minmax' [
   ]
 ]
 
-"Min, max are (or could be, if certain behavior is desired) implemented
- via `minmax` and don't require testing here."
+describe 'min' [
+  it should 'leave min part of minmax' [
+    [ 100 5 -100 2 3 -29 4 500 ] min -100 assert=
+  ]
+]
+
+describe 'max' [
+  it should 'leave max part of minmax' [
+    [ 100 5 -100 2 3 -29 4 500 ] max 500 assert=
+  ]
+]
 
 describe 'sum' [
   it should 'leave 0 when block is empty' [
@@ -945,4 +954,237 @@ describe 'sum' [
 
     sum 603 assert=
   ]
+]
+
+describe 'minmaxBy' [
+  it dies 'when list block is empty' [
+    [ ] [ ] minmaxBy
+  ]
+
+  it should 'leave integer minmax when transform is empty' [
+    [ 1 2 3 ] [ ] minmaxBy stack shallowCopy [ 1 3 ] assert=
+  ]
+
+  it dies 'when transform is empty but values are non-numeric' [
+    [ 'foo' 'barb' 'baz' ] [ ]  minmaxBy
+  ]
+
+  it should 'convert to numeric but leave original types' [
+    [ 'AA' 'A' 'AAAAB' 'BAAAAAAB' 'Y' ] [ charCount ] minmaxBy
+
+    stack shallowCopy [ 'A' 'BAAAAAAB' ] assert=
+  ]
+
+  it should 'support blocks implementing *asDecimal as Transform results' [
+    [ $: s [ s charCount ] @: *asDecimal this ] @: toAwesomeBlock
+
+    [ 'AA' 'A' 'AAAB' 'foo' 'barbeee' ] [ toAwesomeBlock ] minmaxBy
+
+    stack shallowCopy [ 'A' 'barbeee' ] assert=
+  ]
+
+  it dies 'on next' [
+    [ 1 2 3 ] [ break ] minmaxBy
+  ]
+
+  it dies 'on break' [
+    [ 1 2 3 ] [ next ] minmaxBy
+  ]
+]
+
+describe 'minBy' [
+  it should 'leave min from minmaxBy' [
+    [ 'foo' 100 'x' 'buzzer' ] [ dup quote? => [ charCount ] ] minBy 'x' assert=
+  ]
+]
+
+describe 'maxBy' [
+  it should 'leave max from minmaxBy' [
+    [ 'foo' 100 'x' 'buzzer' ] [ dup quote? => [ charCount ] ] maxBy 100 assert=
+  ]
+]
+
+describe 'sumBy' [
+  [ $: s [ s charCount ] @: *asDecimal this ] @: toAwesomeBlock
+
+  it should 'leave zero when list block is empty' [
+    [ ] [ ] sumBy 0 assert=
+  ]
+
+  it should 'leave one numeric if one numeric in list block' [
+    [ 1 ] [ ] sumBy 1 assert=
+    'foo' toAwesomeBlock enclose [ ] sumBy 3 assert=
+  ]
+
+  it should 'sum numerically if transform block is empty' [
+    [ 1 2 3 ] [ ] sumBy 6 assert=
+  ]
+
+  it dies 'when transform block is empty but list block is non-numeric' [
+    [ 1 'foo' #barbee 3 ] [ ] sumBy
+  ]
+
+  it should 'convert to numeric and leave numeric sum & have proper stack signature' [
+    [ ] $: stacks
+
+    [ 'foo' 'bar' 3 4 'x' ] [ stack shallowCopy stacks gulp dup quote? => [ charCount ] ] sumBy
+
+    14 assert=
+
+    stacks [
+      [ 'foo' ]
+      [ 'bar' ]
+      [ 3 ]
+      [ 4 ]
+      [ 'x' ]
+    ] assert=
+  ]
+
+  it should 'support blocks implementing *asDecimal as results/summands' [
+    'foobee' toAwesomeBlock $: myBestBlock
+
+    [ 'foo' 3 myBestBlock 4 'bar' 5 ] here [ dup quote? => [ toAwesomeBlock ] ] sumBy
+
+    24 assert=
+  ]
+
+  it dies 'on next' [
+    [ 1 2 3 ] [ break ] sumBy
+  ]
+
+  it dies 'on break' [
+    [ 1 2 3 ] [ next ] sumBy
+  ]
+]
+
+describe 'collect' [
+  it dies 'when amount is negative' [
+    -1 collect: [ ]
+  ]
+
+  it should 'not call block & leave empty block when N = 0' [
+    false $: called
+    0 collect: [ true =: called ]
+    called not
+  ]
+
+  it should 'collect results of running block N items & have correct stack signature' [
+    [ ] $: stacks
+
+    4 collect: [ stack shallowCopy stacks gulp ] [ 0 1 2 3 ] assert=
+
+    stacks [
+      [ 0 ]
+      [ 1 ]
+      [ 2 ]
+      [ 3 ]
+    ] assert=
+  ]
+
+  it should 'execute block and leave block results' [
+    100 $: n
+    4 collect: [ n + dup =: n ] [ 100 101 103 106 ] assert=
+  ]
+
+  it should 'support next & break' [
+    10 collect: [ $: n
+      n even? => [ next ]
+      n 5 > n odd? and => [ break ]
+      n
+    ] [ 1 3 5 ] assert=
+  ]
+]
+
+describe 'range' [
+  it should 'leave 1-number range when B = E' [
+    0 to: 0 [ 0 ] assert=
+  ]
+
+  it should 'leave 1-number range when B < 0 = E < 0' [
+    -100 to: -100 [ -100 ] assert=
+  ]
+
+  it should 'support [+B; +E]' [
+    1 to: 10 [ 1 2 3 4 5 6 7 8 9 10 ] assert=
+    10 to: 1 [ 10 9 8 7 6 5 4 3 2 1 ] assert=
+  ]
+
+  it should 'support [-B; +E]' [
+    -5 to: 1 [ -5 -4 -3 -2 -1 0 1 ] assert=
+  ]
+
+  it should 'support [+B; -E]' [
+    1 to: -5 [ 1 0 -1 -2 -3 -4 -5 ] assert=
+  ]
+
+  it should 'support [-B; -E]' [
+    -5 to: -10 [ -5 -6 -7 -8 -9 -10 ] assert=
+    -10 to: -5 [ -10 -9 -8 -7 -6 -5 ] assert=
+  ]
+]
+
+describe 'join' [
+  it should 'leave empty quote on empty block' [
+    [ ] join '' assert=
+  ]
+
+  it should 'join one quote' [
+    [ 'foo' ] join 'foo' assert=
+  ]
+
+  it should 'join multiple quotes' [
+    [ 'A' 'B' 'C' ] join 'ABC' assert=
+  ]
+
+  it should 'enquote non-quotes' [
+    [ [ 1 2 3 ] 'foo' 100 bar #baz ##boo ] join '[ 1 2 3 | ]+foo100bar#baz##boo' assert=
+  ]
+]
+
+describe 'concat!' [
+  it should 'concat two empty blocks' [
+    [ ] $: a
+    [ ] $: b
+    a b concat! dup a same? swap [ ] assert= and
+  ]
+
+  it should 'concat with empty A block' [
+    [ ] [ 1 2 3 ] concat! [ 1 2 3 ] assert=
+  ]
+
+  it should 'concat with empty B block' [
+    [ 1 2 3 ] [ ] concat! [ 1 2 3 ] assert=
+  ]
+
+  it should 'concat if both non-empty' [
+    [ 1 2 3 ] $: a
+      a [ 4 5 6 ] concat! a same?
+      a [ 1 2 3 4 5 6 ] assert=
+    and
+  ]
+
+  it should 'move the cursor in A block, but not B block' [
+    [ 1 2 3 ] $: a
+    [ 4 5 6 ] $: b
+    a 1 |to
+    b 2 |to
+    a b concat!
+      a |at 4 assert=
+      b |at 2 assert=
+    and
+  ]
+]
+
+describe 'concat' [
+  it should 'not modify A nor B block' [
+    [ 1 2 3 ] $: a
+    [ 4 5 6 ] $: b
+    a b concat [ 1 2 3 4 5 6 ] assert=
+    a [ 1 2 3 ] assert=
+    b [ 4 5 6 ] assert=
+  ]
+
+  "TODO? Otherwise this is the same as concat! at least in core. Don't know
+   if it's good or bad or worth it to copy tests like that, considering the
+   language may change any minute."
 ]

--- a/tests/block.nk
+++ b/tests/block.nk
@@ -520,3 +520,47 @@ describe 'each' [
     items [ 7 7 1 ] assert=
   ]
 ]
+
+describe 'pairs' [
+  it should 'do nothing if list block is empty' [
+    [ ] pairs: [ + ]
+
+    true
+  ]
+
+  it dies 'when count is odd' [
+    [ 1 2 3 ] pairs: [ + ]
+  ]
+
+
+  it should 'call action block with each pair as stack' [
+    [ ] $: stacks
+
+    [ 1 2 3 4 ] pairs: [ stacks stack shove ]
+
+    stacks [
+      [ 1 2 ]
+      [ 3 4 ]
+    ] assert=
+  ]
+
+  it should 'not modify block when pair populated stack is modified' [
+    [ 1 2 3 4 ] $: a
+    a pairs: [ 1 + ]
+    a [ 1 2 3 4 ] assert=
+  ]
+
+  it should 'support next and break' [
+    [ 1 2 3 4 5 6 7 7 3 4 ] $: a
+
+    [ ] $: visited
+
+    a pairs: [ $: 2i $: 1i
+      1i 2i * odd? => [ break ]
+      1i 2i + 4 >  => [ visited 0 shove next ]
+      visited 1i 2i 2enclose shove
+    ]
+
+    visited [ [ 1 2 ] 0 0 ] assert=
+  ]
+]


### PR DESCRIPTION
`continue` is now `next` because it better describes what happens. Some words that previously did not support `next`/`break` now support them. Also, a gut feeling that the language is faster.

Closes #2.