### PR TITLE
Fix cursor copying in `Block#instance`

### DIFF
--- a/src/novika/tape.cr
+++ b/src/novika/tape.cr
@@ -63,6 +63,11 @@ module Novika
       Tape.new(other.substrate.copy, Math.min(cursor, other.count))
     end
 
+    # See `Substrate#map!`.
+    def map!
+      Tape.new(substrate.map! { |form| yield form }, cursor)
+    end
+
     # Returns a shallow copy of this tape.
     def copy
       Tape.new(substrate.copy, cursor)


### PR DESCRIPTION
* Previously, cursor was not copied in the non-leaf branch of `Block#instance`

* Now, with some cleanup and a `Substrate#map!` method, we (probably) instantiate more efficiently, but what's more important, we instantiate more correctly.

Fixes most of traceback edge cases from #6, an issue that I closed too early...