### PR TITLE
Allow to `count` quotes too instead of `charCount`

### DIFF
--- a/core/block.nk
+++ b/core/block.nk
@@ -834,7 +834,7 @@
   >>> [ 1 2 3 ] [ ] minmaxBy
   === 1 3
 
-  >>> [ 'A short quote' 'A loooonger quote' 'Veeeeeeeeeeery long quote' ] [ charCount ] minmax
+  >>> [ 'A short quote' 'A loooonger quote' 'Veeeeeeeeeeery long quote' ] [ count ] minmax
   === 'A short string' 'Veeeeeeeeeeery long string'
   """
   dup empty? => [ drop minmax ^ ] $: transformer
@@ -882,7 +882,7 @@
 [ """( Lb T -- Sum ): leaves Sum of List block elements transformed
    into decimals by Transformation block. Similar to `minmaxBy`.
 
-  >>> [ 'a' 'aaa' 'aa' ] [ charCount ] sumBy
+  >>> [ 'a' 'aaa' 'aa' ] [ count ] sumBy
   === 6
   """
   $: transformer

--- a/core/quote.nk
+++ b/core/quote.nk
@@ -7,9 +7,9 @@
      the language's shaky philosophy of having more-or-less type-
      centric words."
     'toCapitalized expected a quote, got: ' qq enquote stitch die
-  ] 
+  ]
 
-  qq charCount 
+  qq count
     dup 0 = => [ qq ^ ]
     dup 1 = => [ drop qq toUppercase ^ ]
     drop

--- a/tests/block.nk
+++ b/tests/block.nk
@@ -1002,13 +1002,13 @@ describe 'minmaxBy' [
   ]
 
   it should 'convert to numeric but leave original types' [
-    [ 'AA' 'A' 'AAAAB' 'BAAAAAAB' 'Y' ] [ charCount ] minmaxBy
+    [ 'AA' 'A' 'AAAAB' 'BAAAAAAB' 'Y' ] [ count ] minmaxBy
 
     stack shallowCopy [ 'A' 'BAAAAAAB' ] assert=
   ]
 
   it should 'support blocks implementing *asDecimal as Transform results' [
-    [ $: s [ s charCount ] @: *asDecimal this ] @: toAwesomeBlock
+    [ $: s [ s count ] @: *asDecimal this ] @: toAwesomeBlock
 
     [ 'AA' 'A' 'AAAB' 'foo' 'barbeee' ] [ toAwesomeBlock ] minmaxBy
 
@@ -1026,18 +1026,18 @@ describe 'minmaxBy' [
 
 describe 'minBy' [
   it should 'leave min from minmaxBy' [
-    [ 'foo' 100 'x' 'buzzer' ] [ dup quote? => [ charCount ] ] minBy 'x' assert=
+    [ 'foo' 100 'x' 'buzzer' ] [ dup quote? => [ count ] ] minBy 'x' assert=
   ]
 ]
 
 describe 'maxBy' [
   it should 'leave max from minmaxBy' [
-    [ 'foo' 100 'x' 'buzzer' ] [ dup quote? => [ charCount ] ] maxBy 100 assert=
+    [ 'foo' 100 'x' 'buzzer' ] [ dup quote? => [ count ] ] maxBy 100 assert=
   ]
 ]
 
 describe 'sumBy' [
-  [ $: s [ s charCount ] @: *asDecimal this ] @: toAwesomeBlock
+  [ $: s [ s count ] @: *asDecimal this ] @: toAwesomeBlock
 
   it should 'leave zero when list block is empty' [
     [ ] [ ] sumBy 0 assert=
@@ -1059,7 +1059,7 @@ describe 'sumBy' [
   it should 'convert to numeric and leave numeric sum & have proper stack signature' [
     [ ] $: stacks
 
-    [ 'foo' 'bar' 3 4 'x' ] [ stack shallowCopy stacks gulp dup quote? => [ charCount ] ] sumBy
+    [ 'foo' 'bar' 3 4 'x' ] [ stack shallowCopy stacks gulp dup quote? => [ count ] ] sumBy
 
     14 assert=
 

--- a/tests/essential.nk
+++ b/tests/essential.nk
@@ -1,3 +1,21 @@
+describe 'count' [
+  it should 'leave 0 for empty block' [
+    [ ] count 0 assert=
+  ]
+
+  it should 'leave 0 for empty quote' [
+    '' count 0 assert=
+  ]
+
+  it should 'count the amount of elements in blocks' [
+    [ 1 2 3 4 ] count 4 assert=
+  ]
+
+  it should 'count the amount of characters (graphemes) in quotes' [
+    'Ⓐs°Ämanчеловек' count 14 assert=
+  ]
+]
+
 describe 'asWord' [
   it should 'noop if already word' [
     #hello asWord #hello assert=
@@ -134,7 +152,7 @@ describe 'sliceQuoteAt' [
     'foobar' -1 sliceQuoteAt
   ]
 
-  it dies 'when slicepoint > quote charCount' [
+  it dies 'when slicepoint > quote count' [
     'foobar' 7 sliceQuoteAt
   ]
 
@@ -142,7 +160,7 @@ describe 'sliceQuoteAt' [
     [ ] [ 'foobar' 0 sliceQuoteAt ] there [ '' 'foobar' ] assert=
   ]
 
-  it should 'handle slicepoint quote charCount = case' [
+  it should 'handle slicepoint quote count = case' [
     [ ] [ 'foobar' 6 sliceQuoteAt ] there [ 'foobar' '' ] assert=
   ]
 


### PR DESCRIPTION
This change is bad and good at the same time. Anyway, it lets us reuse a lot of code from blocks.

E.g. `'hello world' count` works now as well as `[ 1 2 3 ] count`.