### PR TITLE
Fix conversion word lookup

### DIFF
--- a/core/block.nk
+++ b/core/block.nk
@@ -968,7 +968,7 @@
   >>> [ x '; ' y ] here join
   === '1; 2'
   """
-  [ enquote stitch ] '' reduce
+  [ toQuote stitch ] '' reduce
 ] @: join
 
 

--- a/core/core.nk
+++ b/core/core.nk
@@ -130,7 +130,7 @@ _root #@: [
 
 [ "( needs: Pq -- ): ensures that the user has enabled the package
    with id specified by Package quote."
-  ahead eject enquote $: packageId
+  ahead eject toQuote $: packageId
 
   novika:packages [ packageId = ] any? not =>
     [

--- a/core/fs/file.nk
+++ b/core/fs/file.nk
@@ -5,7 +5,7 @@
   path . available? $: available?
 
   [ available? not ] [ path . file? ] or not
-    => [ 'File needs a file path, but got: ' path enquote stitch die ]
+    => [ 'File needs a file path, but got: ' path toQuote stitch die ]
 
   [ "( -- Pq ): leaves the Path quote."
     path . pathQuote

--- a/core/quote.nk
+++ b/core/quote.nk
@@ -6,7 +6,7 @@
     "We could have enquoted it of course, but that would be against
      the language's shaky philosophy of having more-or-less type-
      centric words."
-    'toCapitalized expected a quote, got: ' qq enquote stitch die
+    'toCapitalized expected a quote, got: ' qq toQuote stitch die
   ]
 
   qq count

--- a/core/test.nk
+++ b/core/test.nk
@@ -12,7 +12,7 @@
   There is also a natural language-like word, `is`, which doesn't do much
   other than `ahead eject`ing the action. The following works exactly
   the same as the code above:
-  
+
   >>> describe '+ word' [
     it should 'add numbers' [ 1 1 + 2 = ]
     it dies 'when adding wrong types' [ 1 '2' + ]
@@ -49,7 +49,7 @@
     deathHandlerBlock testCaseBlock parent reparent
     deathHandlerBlock #*died deathHandler opens
 
-    [ "( Fa Fb -- true/false ): adds an 'Fa is not Fb' message and 
+    [ "( Fa Fb -- true/false ): adds an 'Fa is not Fb' message and
        leaves false when that is the case (determined using `=`); in
        case 'Fa is Fb', leaves true and prints nothing."
       $: b $: a
@@ -91,7 +91,7 @@
   [ "( D Cb -- ): reports failure outcome given Description
      and Comments block."
     $: comments
-    
+
     FAILURE-RGB withEchoFg
       ' × ' swap stitch withColorEcho
     dropEchoFg
@@ -158,7 +158,7 @@
       AFTER IT: <nothing> | itShould ...
     """
 
-    ahead 'it' name enquote toCapitalized stitch asWord inject
+    ahead 'it' name enquote toCapitalized stitch toWord inject
   ] opens
 
   sectionBlockInstance #itDies itDiesImpl opens

--- a/core/test.nk
+++ b/core/test.nk
@@ -54,8 +54,8 @@
        case 'Fa is Fb', leaves true and prints nothing."
       $: b $: a
       a b = [
-        'Expected: ' b enquote stitch ', got: ' stitch
-                     a enquote stitch
+        'Expected: ' b toQuote stitch ', got: ' stitch
+                     a toQuote stitch
                      comments gulp
         false
       ] or
@@ -158,7 +158,7 @@
       AFTER IT: <nothing> | itShould ...
     """
 
-    ahead 'it' name enquote toCapitalized stitch toWord inject
+    ahead 'it' name toQuote toCapitalized stitch toWord inject
   ] opens
 
   sectionBlockInstance #itDies itDiesImpl opens
@@ -174,18 +174,18 @@
   '=== Summary for ' sectionName stitch echo
 
   SUCCESS-RGB withEchoFg
-    ' ✔ Successful cases: ' successes enquote stitch withColorEcho
+    ' ✔ Successful cases: ' successes toQuote stitch withColorEcho
   dropEchoFg
 
   failures 0 > => [
     FAILURE-RGB withEchoFg
-      ' × Failures: ' failures enquote stitch withColorEcho
+      ' × Failures: ' failures toQuote stitch withColorEcho
     dropEchoFg
   ]
 
   deaths 0 > => [
     DEATH-RGB withEchoFg
-      ' ☨ Deaths: ' deaths enquote stitch withColorEcho
+      ' ☨ Deaths: ' deaths toQuote stitch withColorEcho
     dropEchoFg
   ]
 

--- a/examples/hello.nk
+++ b/examples/hello.nk
@@ -43,7 +43,7 @@ consProduct echo
   $: x
 
   [
-    [ ] x enquote <<  ' @ ' << y enquote <<
+    [ ] x toQuote <<  ' @ ' << y toQuote <<
     [ stitch ] '' reduce
   ] @: *asQuote
 

--- a/examples/html.nk
+++ b/examples/html.nk
@@ -8,7 +8,7 @@
 'expected attribute to be a quote, got: '           $: HTML_ATTR_ERR
 'expected value of argument to be a quote, got: '   $: HTML_VAL_ERR
 
-[ enquote stitch die ] @: 2die
+[ toQuote stitch die ] @: 2die
 [ [ ' ' swap ] |slideLeft join ] @: prefixedByWs
 
 [ $: htmlBlock
@@ -55,7 +55,7 @@
     >>> div [ class: 'main' div [ class: 'wrapper' h1 [ 'Hi!' ] ] ]
     === <div class='main'><div class='wrapper'><h1>Hi!</h1></div></div>
     """
-    enquote $: tagName
+    toQuote $: tagName
 
     ahead $: outer
     ahead eject $: argument

--- a/src/novika/forms/block.cr
+++ b/src/novika/forms/block.cr
@@ -395,7 +395,7 @@ module Novika
       end || afail(T)
     end
 
-    def enquote(engine : Engine) : Quote
+    def to_quote(engine : Engine) : Quote
       assert?(engine, AS_QUOTE, Quote) || super
     end
 

--- a/src/novika/forms/block.cr
+++ b/src/novika/forms/block.cr
@@ -31,9 +31,6 @@ module Novika
     # of *nested* blocks.
     MAX_NESTED_COUNT_TO_S = 12
 
-    # Block to boolean hook name.
-    AS_BOOL = Word.new("*asBool")
-
     # Block to word hook name.
     AS_WORD = Word.new("*asWord")
 
@@ -42,6 +39,12 @@ module Novika
 
     # Block to decimal hook name.
     AS_DECIMAL = Word.new("*asDecimal")
+
+    # Block to boolean hook name.
+    AS_BOOLEAN = Word.new("*asBoolean")
+
+    # Block to quoted word hook name.
+    AS_QUOTED_WORD = Word.new("*asQuotedWord")
 
     # Returns and allows to set whether this block is a leaf.
     # A block is a leaf when it has no blocks in its tape.
@@ -384,10 +387,11 @@ module Novika
       return self if is_a?(T)
 
       case T
-      when Decimal.class then assert?(engine, AS_DECIMAL, type)
-      when Quote.class   then assert?(engine, AS_QUOTE, type)
-      when Word.class    then assert?(engine, AS_WORD, type)
-      when Boolean.class then assert?(engine, AS_BOOL, type)
+      when Decimal.class    then assert?(engine, AS_DECIMAL, type)
+      when Quote.class      then assert?(engine, AS_QUOTE, type)
+      when Word.class       then assert?(engine, AS_WORD, type)
+      when Boolean.class    then assert?(engine, AS_BOOLEAN, type)
+      when QuotedWord.class then assert?(engine, AS_QUOTED_WORD, type)
       end || afail(T)
     end
 

--- a/src/novika/forms/block.cr
+++ b/src/novika/forms/block.cr
@@ -373,7 +373,7 @@ module Novika
     # Assert through the result of running *name*'s value in
     # this block's table.
     private def assert?(engine : Engine, name : Form, type : T.class) : T? forall T
-      return unless form = at?(name)
+      form = table.get(name) { return }
       result = engine[form, push(self.class.new)].drop
       unless result.is_a?(Block) && same?(result)
         result.assert(engine, T)

--- a/src/novika/forms/form.cr
+++ b/src/novika/forms/form.cr
@@ -81,7 +81,7 @@ module Novika
 
     # Returns this form's quote representation. May run Novika,
     # hence the need for *engine*.
-    def enquote(engine : Engine) : Quote
+    def to_quote(engine : Engine) : Quote
       Quote.new(to_s)
     end
   end

--- a/src/novika/forms/quote.cr
+++ b/src/novika/forms/quote.cr
@@ -118,7 +118,7 @@ module Novika
       at?(index) || die("grapheme index out of bounds: #{index}")
     end
 
-    def enquote(engine : Engine) : Quote
+    def to_quote(engine : Engine) : Quote
       self
     end
   end

--- a/src/novika/packages/impl/colors.cr
+++ b/src/novika/packages/impl/colors.cr
@@ -17,7 +17,7 @@ module Novika::Packages::Impl
     end
 
     def with_color_echo(engine, fg : Color?, bg : Color?, form : Form)
-      string = form.enquote(engine).string
+      string = form.to_quote(engine).string
 
       colorful = string.colorize
       colorful = colorful.fore(*color_u8(*fg)) if fg

--- a/src/novika/packages/impl/essential.cr
+++ b/src/novika/packages/impl/essential.cr
@@ -120,7 +120,7 @@ module Novika::Packages::Impl
         Boolean[engine.stack.drop.is_a?(Word)].push(engine)
       end
 
-      target.at("asWord", <<-END
+      target.at("toWord", <<-END
       ( F -- W ): converts Form into Word.
         1. If Form is a word, behaves as noop
         2. If Form is a quote, dies only if quote contains (Unicode) whitespace characters
@@ -135,13 +135,13 @@ module Novika::Packages::Impl
         when Quote
           string = form.string
           if string.empty?
-            form.die("asWord: quote argument is empty")
+            form.die("toWord: quote argument is empty")
           elsif string.each_char.any?(&.whitespace?)
-            form.die("asWord: quote argument contains whitespace")
+            form.die("toWord: quote argument contains whitespace")
           end
           Word.new(form.string).push(engine)
         else
-          form.die("asWord: quote must be one of: word, quote, quoted word")
+          form.die("toWord: quote must be one of: word, quote, quoted word")
         end
       end
 

--- a/src/novika/packages/impl/essential.cr
+++ b/src/novika/packages/impl/essential.cr
@@ -116,6 +116,26 @@ module Novika::Packages::Impl
         Boolean[engine.stack.drop.is_a?(Block)].push(engine)
       end
 
+      target.at("asBlock", <<-END
+      ( F -- B ): asserts that Form is a Block, dies otherwise.
+
+      >>> 100 asBlock
+      [dies]
+      >>> 'foo' asBlock
+      [dies]
+      >>> #foo asBlock
+      [dies]
+      >>> ##foo asBlock
+      [dies]
+      >>> [] asBlock
+      === [] (the same block)
+      >>> true asBlock
+      [dies]
+      END
+      ) do |engine|
+        engine.stack.top.assert(engine, Block)
+      end
+
       target.at("word?", "( F -- true/false ): leaves whether Form is a word.") do |engine|
         Boolean[engine.stack.drop.is_a?(Word)].push(engine)
       end
@@ -145,20 +165,200 @@ module Novika::Packages::Impl
         end
       end
 
+      target.at("asWord", <<-END
+      ( F -- W ): asserts that Form is a Word, dies otherwise.
+
+      Tries to invoke *asWord while Form or result thereof is
+      a block.
+
+      >>> 100 asWord
+      [dies]
+      >>> 'foo' asWord
+      [dies]
+      >>> #foo asWord
+      === foo
+      >>> ##foo asWord
+      [dies]
+      >>> [] asWord
+      [dies]
+      >>> true asWord
+      [dies]
+      >>> [ $: x x $: *asWord this ] @: a
+      >>> 100 a asWord
+      [dies]
+      >>> 'foo' a asWord
+      [dies]
+      >>> #foo a asWord
+      === instance of a
+      >>> ##foo asWord
+      [dies]
+      >>> [] a asWord
+      [dies]
+      >>> true a asWord
+      [dies]
+      END
+      ) do |engine|
+        engine.stack.top.assert(engine, Word)
+      end
+
       target.at("quotedWord?", "( F -- true/false ): leaves whether Form is a quoted word.") do |engine|
         Boolean[engine.stack.drop.is_a?(QuotedWord)].push(engine)
+      end
+
+      target.at("asQuotedWord", <<-END
+      ( F -- Qw ): asserts that Form is a Quoted word, dies otherwise.
+
+      Tries to invoke *asQuotedWord while Form or result thereof is
+      a block implementing *asQuotedWord.
+
+      >>> 100 asQuotedWord
+      [dies]
+      >>> 'foo' asQuotedWord
+      [dies]
+      >>> #foo asQuotedWord
+      [dies]
+      >>> ##foo asQuotedWord
+      === #foo
+      >>> [] asQuotedWord
+      [dies]
+      >>> true asQuotedWord
+      [dies]
+      >>> [ $: x x $: *asQuotedWord this ] @: a
+      >>> 100 a asQuotedWord
+      [dies]
+      >>> 'foo' a asQuotedWord
+      [dies]
+      >>> #foo a asQuotedWord
+      [dies]
+      >>> ##foo a asQuotedWord
+      === instance of a
+      >>> [] a asQuotedWord
+      [dies]
+      >>> true a asQuotedWord
+      [dies]
+      END
+      ) do |engine|
+        engine.stack.top.assert(engine, QuotedWord)
       end
 
       target.at("decimal?", "( F -- true/false ): leaves whether Form is a decimal.") do |engine|
         Boolean[engine.stack.drop.is_a?(Decimal)].push(engine)
       end
 
+      target.at("asDecimal", <<-END
+      ( F -- D ): asserts that Form is a Decimal, dies otherwise.
+
+      Tries to invoke *asDecimal while Form or result thereof is
+      a block implementing *asDecimal.
+
+      >>> 100 asDecimal
+      === 100
+      >>> 'foo' asDecimal
+      [dies]
+      >>> #foo asDecimal
+      [dies]
+      >>> ##foo asDecimal
+      [dies]
+      >>> [] asDecimal
+      [dies]
+      >>> true asDecimal
+      [dies]
+      >>> [ $: x x $: *asDecimal this ] @: a
+      >>> 100 a asDecimal
+      === instance of a
+      >>> 'foo' a asDecimal
+      [dies]
+      >>> #foo a asDecimal
+      [dies]
+      >>> ##foo a asDecimal
+      [dies]
+      >>> [] a asDecimal
+      [dies]
+      >>> true a asDecimal
+      [dies]
+      END
+      ) do |engine|
+        engine.stack.top.assert(engine, Decimal)
+      end
+
       target.at("quote?", "( F -- true/false ): leaves whether Form is a quote.") do |engine|
         Boolean[engine.stack.drop.is_a?(Quote)].push(engine)
       end
 
+      target.at("asQuote", <<-END
+      ( F -- Q ): asserts that Form is a Quote, dies otherwise.
+
+      Tries to invoke *asQuote while Form or result thereof is
+      a block implementing *asQuote.
+
+      >>> 100 asQuote
+      [dies]
+      >>> 'foo' asQuote
+      === 'foo'
+      >>> #foo asQuote
+      [dies]
+      >>> ##foo asQuote
+      [dies]
+      >>> [] asQuote
+      [dies]
+      >>> true asQuote
+      [dies]
+      >>> [ $: x x $: *asQuote this ] @: a
+      >>> 100 a asQuote
+      [dies]
+      >>> 'foo' a asQuote
+      === instance of a
+      >>> #foo a asQuote
+      [dies]
+      >>> ##foo a asQuote
+      [dies]
+      >>> [] a asQuote
+      [dies]
+      >>> true a asQuote
+      [dies]
+      END
+      ) do |engine|
+        engine.stack.top.assert(engine, Quote)
+      end
+
       target.at("boolean?", "( F -- true/false ): leaves whether Form is a boolean.") do |engine|
         Boolean[engine.stack.drop.is_a?(Boolean)].push(engine)
+      end
+
+      target.at("asBoolean", <<-END
+      ( F -- B ): asserts that Form is a Boolean, dies otherwise.
+
+      Tries to invoke *asBoolean while Form or result thereof is
+      a block implementing *asBoolean.
+
+      >>> 100 asBoolean
+      [dies]
+      >>> 'foo' asBoolean
+      [dies]
+      >>> #foo asBoolean
+      [dies]
+      >>> ##foo asBoolean
+      [dies]
+      >>> [] asBoolean
+      [dies]
+      >>> true asBoolean
+      === true
+      >>> [ $: x x $: *asBoolean this ] @: a
+      >>> 100 a asBoolean
+      [dies]
+      >>> 'foo' a asBoolean
+      [dies]
+      >>> #foo a asBoolean
+      [dies]
+      >>> ##foo a asBoolean
+      [dies]
+      >>> [] a asBoolean
+      [dies]
+      >>> true a asBoolean
+      === instance of a
+      END
+      ) do |engine|
+        engine.stack.top.assert(engine, Boolean)
       end
 
       target.at("pushes", <<-END

--- a/src/novika/packages/impl/essential.cr
+++ b/src/novika/packages/impl/essential.cr
@@ -574,8 +574,8 @@ module Novika::Packages::Impl
         recpt.import!(from: donor)
       end
 
-      target.at("enquote", "( F -- Qr ): leaves Quote representation of Form.") do |engine|
-        engine.stack.drop.enquote(engine).push(engine)
+      target.at("toQuote", "( F -- Qr ): leaves Quote representation of Form.") do |engine|
+        engine.stack.drop.to_quote(engine).push(engine)
       end
 
       target.at("die", "( D -- ): dies with Details quote.") do |engine|

--- a/src/novika/packages/impl/system.cr
+++ b/src/novika/packages/impl/system.cr
@@ -1,11 +1,11 @@
 module Novika::Packages::Impl
   class System < ISystem
     def echo(engine, form : Form)
-      puts form.enquote(engine).string
+      puts form.to_quote(engine).string
     end
 
     def readline(engine, prompt : Form) : {Quote, Boolean}
-      string = prompt.enquote(engine).string
+      string = prompt.to_quote(engine).string
       answer = nil
       {% if flag?(:novika_readline) %}
         answer = Readline.readline(string)

--- a/tests/block.nk
+++ b/tests/block.nk
@@ -321,7 +321,7 @@ describe '|slideRight' [
       dup 15 /?  => [ drop 'FizzBuzz' next ]
       dup  5 /?  => [ drop 'Buzz' next ]
       dup  3 /?  => [ drop 'Fizz' next ]
-      enquote
+      toQuote
     ]
 
     [ '1' '2' 'Fizz' '4' 'Buzz' 'Fizz' '7' '8' 'Fizz' 'Buzz' '11' 'Fizz'
@@ -912,7 +912,7 @@ describe 'conjure/here' [
   ]
 
   it should 'trigger word trap when word is undefined' [
-    [ enquote 1 sliceQuoteAt nip ] @: *trap
+    [ toQuote 1 sliceQuoteAt nip ] @: *trap
     foobar here 'oobar' assert=
   ]
 ]

--- a/tests/bugs.nk
+++ b/tests/bugs.nk
@@ -31,3 +31,33 @@ describe 'Handle infinite block instantiation #22' [
     y y = x 0 fromLeft y = not assert=
   ]
 ]
+
+describe 'Conversion words should not be inherited #25' [
+  [
+    [ ] $: x
+
+    'hello' $: *asQuote
+    [ 100 1 + ] @: *asDecimal
+    false $: *asBoolean
+    [ ##fubar ] @: *asQuotedWord
+    [ [ #baz $: *asWord this ] open ] @: *asWord
+
+    this
+  ] @: b
+
+  it dies 'because child doesn\'t inherit *asQuote' [ b.x asQuote ]
+  it dies 'because child doesn\'t inherit *asDecimal' [ b.x asDecimal ]
+  it dies 'because child doesn\'t inherit *asBoolean' [ b.x asBoolean ]
+  it dies 'because child doesn\'t inherit *asQuotedWord' [ b.x asQuotedWord ]
+  it dies 'because child doesn\'t inherit *asWord' [ b.x asWord ]
+
+  [ [ ] $: x 'hello' $: *asQuote this ] @: issueEg1
+  [ [ ] $: x [ 100 1 + ] @: *asDecimal this ] @: issueEg2
+
+  it should 'pass issue example #1' [ issueEg1 dup asQuote assert= ]
+  it dies 'as expected in issue example #1' [ issueEg1.x asQuote ]
+
+  it should 'pass issue example #2' [ issueEg2 1 + 102 assert= ]
+  it dies 'as expected in issue example #2' [ issueEg2.x 1 +  ]
+
+]

--- a/tests/decimal.nk
+++ b/tests/decimal.nk
@@ -176,7 +176,7 @@ describe '*asDecimal hook for implicit conversion of blocks to decimals' [
   ]
 
   itDies 'when block does not return a decimal in *asDecimal' [
-    [ enquote $: *asDecimal this ] @: wrap
+    [ toQuote $: *asDecimal this ] @: wrap
     1 2 wrap +
   ]
 

--- a/tests/essential.nk
+++ b/tests/essential.nk
@@ -1,3 +1,124 @@
+describe 'asDecimal' [
+  it dies 'when given quote' [ 'foo' asDecimal ]
+  it dies 'when given word' [ #foo asDecimal ]
+  it dies 'when given quoted word' [ ##foo asDecimal ]
+  it dies 'when given boolean' [ true asDecimal ]
+  it dies 'when given block' [ [] asDecimal ]
+  it should 'leave decimal when given decimal' [
+    100 dup asDecimal assert=
+  ]
+
+  [ $: x x $: *asDecimal this ] @: a
+
+  it dies 'when given quote in *asDecimal' [ 'foo' a asDecimal ]
+  it dies 'when given word in *asDecimal' [ #foo a asDecimal ]
+  it dies 'when given quoted word in *asDecimal' [ ##foo a asDecimal ]
+  it dies 'when given boolean in *asDecimal' [ true a asDecimal ]
+  it dies 'when given block in *asDecimal' [ [] a asDecimal ]
+  it should 'leave instance when given decimal in *asDecimal' [
+    100 a dup asDecimal same?
+  ]
+]
+
+describe 'asQuote' [
+  it dies 'when given decimal' [ 100 asQuote ]
+  it dies 'when given word' [ #foo asQuote ]
+  it dies 'when given quoted word' [ ##foo asQuote ]
+  it dies 'when given boolean' [ true asQuote ]
+  it dies 'when given block' [ [] asQuote ]
+  it should 'leave quote when given quote' [
+    'foo' dup asQuote assert=
+  ]
+
+  [ $: x x $: *asQuote this ] @: a
+
+  it dies 'when given decimal in *asQuote' [ 100 a asQuote ]
+  it dies 'when given word in *asQuote' [ #foo a asQuote ]
+  it dies 'when given quoted word in *asQuote' [ ##foo a asQuote ]
+  it dies 'when given boolean in *asQuote' [ true a asQuote ]
+  it dies 'when given block in *asQuote' [ [] a asQuote ]
+  it should 'leave instance when given quote in *asQuote' [
+    'foo' a dup asQuote same?
+  ]
+]
+
+describe 'asWord' [
+  it dies 'when given decimal' [ 100 asWord ]
+  it dies 'when given quote' [ 'foo' asWord ]
+  it dies 'when given quoted word' [ ##foo asWord ]
+  it dies 'when given boolean' [ true asWord ]
+  it dies 'when given block' [ [] asWord ]
+  it should 'leave word when given word' [
+    #foo dup asWord assert=
+  ]
+
+  [ $: x x $: *asWord this ] @: a
+
+  it dies 'when given decimal in *asWord' [ 100 a asWord ]
+  it dies 'when given quote in *asWord' [ 'foo' a asWord ]
+  it dies 'when given quoted word in *asWord' [ ##foo a asWord ]
+  it dies 'when given boolean in *asWord' [ true a asWord ]
+  it dies 'when given block in *asWord' [ [] a asWord ]
+  it should 'leave instance when given word in *asWord' [
+    #foo a dup asWord same?
+  ]
+]
+
+describe 'asQuotedWord' [
+  it dies 'when given decimal' [ 100 asQuotedWord ]
+  it dies 'when given quote' [ 'foo' asQuotedWord ]
+  it dies 'when given word' [ #foo asQuotedWord ]
+  it dies 'when given boolean' [ true asQuotedWord ]
+  it dies 'when given block' [ [] asQuotedWord ]
+  it should 'leave quoted word when given quoted word' [
+    ##foo dup asQuotedWord assert=
+  ]
+
+  [ $: x x $: *asQuotedWord this ] @: a
+
+  it dies 'when given decimal in *asQuotedWord' [ 100 a asQuotedWord ]
+  it dies 'when given quote in *asQuotedWord' [ 'foo' a asQuotedWord ]
+  it dies 'when given word in *asQuotedWord' [ #foo a asQuotedWord ]
+  it dies 'when given boolean in *asQuotedWord' [ true a asQuotedWord ]
+  it dies 'when given block in *asQuotedWord' [ [] a asQuotedWord ]
+  it should 'leave instance when given quoted word in *asQuotedWord' [
+    ##foo a dup asQuotedWord same?
+  ]
+]
+
+describe 'asBoolean' [
+  it dies 'when given decimal' [ 100 asBoolean ]
+  it dies 'when given quote' [ 'foo' asBoolean ]
+  it dies 'when given word' [ #foo asBoolean ]
+  it dies 'when given quoted word' [ ##foo asBoolean ]
+  it dies 'when given block' [ [] asBoolean ]
+  it should 'leave boolean when given boolean' [
+    true dup asBoolean assert=
+  ]
+
+  [ $: x x $: *asBoolean this ] @: a
+
+  it dies 'when given decimal in *asBoolean' [ 100 a asBoolean ]
+  it dies 'when given quote in *asBoolean' [ 'foo' a asBoolean ]
+  it dies 'when given word in *asBoolean' [ #foo a asBoolean ]
+  it dies 'when given quoted word in *asBoolean' [ ##foo a asBoolean ]
+  it dies 'when given block in *asBoolean' [ [] a asBoolean ]
+  it should 'leave instance when given boolean in *asBoolean' [
+    true a dup asBoolean same?
+  ]
+]
+
+describe 'asBlock' [
+  it dies 'when given decimal' [ 100 asBlock ]
+  it dies 'when given quote' [ 'foo' asBlock ]
+  it dies 'when given word' [ #foo asBlock ]
+  it dies 'when given quoted word' [ ##foo asBlock ]
+  it dies 'when given boolean' [ true asBlock ]
+  it should 'leave same block when given block' [
+    [] dup asBlock same?
+  ]
+]
+
 describe 'quote?' [
   it should 'leave false for block' [ [ ] quote? not ]
   it should 'leave false for true' [ true quote? not ]

--- a/tests/essential.nk
+++ b/tests/essential.nk
@@ -142,40 +142,40 @@ describe 'fromLeft' [
   ]
 ]
 
-describe 'asWord' [
+describe 'toWord' [
   it should 'noop if already word' [
-    #hello asWord #hello assert=
+    #hello toWord #hello assert=
   ]
 
   it should 'convert quote to word' [
-    'hello' asWord #hello assert=
+    'hello' toWord #hello assert=
   ]
 
   it should 'peel off all quoting' [
-    ########hello asWord #hello assert=
+    ########hello toWord #hello assert=
   ]
 
   it should 'convert when quote has grapheme clusters' [
-    'x👻👺🤖' asWord #x👻👺🤖 assert=
+    'x👻👺🤖' toWord #x👻👺🤖 assert=
   ]
 
   it dies 'when quote is empty' [
-    '' asWord
+    '' toWord
   ]
 
   it dies 'when quote is whitespace' [
-    ' ' asWord
+    ' ' toWord
   ]
 
   it dies 'when quote is newline + whitespace' [
     '
 
 
-    ' asWord
+    ' toWord
   ]
 
   it dies 'when quote contains whitespace' [
-    'hello world' asWord
+    'hello world' toWord
   ]
 ]
 

--- a/tests/essential.nk
+++ b/tests/essential.nk
@@ -14,18 +14,18 @@ describe 'quote?' [
   ]
 ]
 
-describe 'enquote' [
+describe 'toQuote' [
   "TODO: enquote block. It needs a pretty large set of tests
    for itself."
-  it should 'enquote boolean true' [ true enquote 'true' assert= ]
-  it should 'enquote boolean false' [ false enquote 'false' assert= ]
-  it should 'enquote builtin' [ #+ here enquote '[native code]' assert= ]
-  it should 'enquote decimal' [ 100 enquote '100' assert= ]
-  it should 'enquote -decimal' [ -100 enquote '-100' assert= ]
-  it should 'enquote +decimal' [ +100 enquote '100' assert= ]
-  it should 'enquote quote' [ 'hello world' enquote 'hello world' assert= ]
-  it should 'enquote word' [ #hello enquote 'hello' assert= ]
-  it should 'enquote quoted word' [ ##hello enquote '#hello' assert= ]
+  it should 'enquote boolean true' [ true toQuote 'true' assert= ]
+  it should 'enquote boolean false' [ false toQuote 'false' assert= ]
+  it should 'enquote builtin' [ #+ here toQuote '[native code]' assert= ]
+  it should 'enquote decimal' [ 100 toQuote '100' assert= ]
+  it should 'enquote -decimal' [ -100 toQuote '-100' assert= ]
+  it should 'enquote +decimal' [ +100 toQuote '100' assert= ]
+  it should 'enquote quote' [ 'hello world' toQuote 'hello world' assert= ]
+  it should 'enquote word' [ #hello toQuote 'hello' assert= ]
+  it should 'enquote quoted word' [ ##hello toQuote '#hello' assert= ]
 ]
 
 describe 'stitch' [

--- a/world/world.cr
+++ b/world/world.cr
@@ -48,7 +48,7 @@ class IOMod
 
   def inject(into target)
     target.at("echo", "( F -- ): shows Form in the console.") do |world|
-      quote = world.stack.drop.enquote(world)
+      quote = world.stack.drop.to_quote(world)
       @player.println(quote.string)
     end
 
@@ -58,7 +58,7 @@ class IOMod
      bool. If rejected, Answer quote is empty.
     END
     ) do |world|
-      prompt = world.stack.drop.enquote(world)
+      prompt = world.stack.drop.to_quote(world)
       @player.request_user_input(prompt.string, @ichan)
       answer = @ichan.receive
       Novika::Quote.new(answer || "").push(world)


### PR DESCRIPTION
Minor and major renames to maintain the symmetry of words:

  * `asWord` -> `toWord`: `'foo' toWord` -> `foo` (a word)

  * `enquote` -> `toQuote` (but verb still the same: to enquote smth means to use `toQuote` smth)

Add missing assert-type words `asWord`, `asQuote`, `asBlock`, etc. Under the hood, they do `form.assert(engine, T)`.

Fixes #25.