### PR TITLE
Implement proper `Form.typedesc` instead of `Form.desc` et al.

### DIFF
--- a/src/novika/engine.cr
+++ b/src/novika/engine.cr
@@ -44,8 +44,6 @@ module Novika
   # so on, up until there are no scheduled blocks
   # (continuations) left.
   struct Engine
-    include Form
-
     # Maximum amount of scheduled continuations in `conts`. After
     # passing this number, `Died` is raised to bring attention
     # to such dangerous depth.

--- a/src/novika/errors.cr
+++ b/src/novika/errors.cr
@@ -20,7 +20,6 @@ module Novika
   # Raised when a form dies.
   class Died < Exception
     include Form
-    extend HasDesc
 
     # How many trace entries to display at max.
     MAX_TRACE = 64
@@ -39,8 +38,8 @@ module Novika
       io << "error: '" << details << "'"
     end
 
-    def self.desc(io : IO)
-      io << "an error"
+    def self.typedesc
+      "error"
     end
 
     # Appends a report about this error to *io*.

--- a/src/novika/forms/block.cr
+++ b/src/novika/forms/block.cr
@@ -92,10 +92,12 @@ module Novika
       @comment unless @comment.try &.empty?
     end
 
-    # Sets the block comment of this block to *comment*
-    # in case it doesn't have a comment already.
-    def describe_with?(comment comment_ : String) : String?
-      @comment = comment_ unless @comment
+    # Sets the block comment of this block to *comment* in
+    # case it doesn't have a comment already.
+    #
+    # Setting the comment can also be forced by making *force* true.
+    def describe_with?(comment : String, force = false) : String?
+      @comment = comment if force || !comment?
     end
 
     # See the same method in `Tape`.

--- a/src/novika/forms/block.cr
+++ b/src/novika/forms/block.cr
@@ -22,7 +22,6 @@ module Novika
   # wants or needs to.
   class Block
     include Form
-    extend HasDesc
 
     # Maximum amount of forms to display in block string representation.
     MAX_COUNT_TO_S = 128
@@ -83,8 +82,8 @@ module Novika
       io << (prototype.comment? || "a block")
     end
 
-    def self.desc(io)
-      io << "a block"
+    def self.typedesc
+      "block"
     end
 
     # Returns this block's comment, or nil if the comment was

--- a/src/novika/forms/boolean.cr
+++ b/src/novika/forms/boolean.cr
@@ -2,7 +2,6 @@ module Novika
   # Represents a boolean (true/false) value.
   abstract struct Boolean
     include Form
-    extend HasDesc
 
     # Creates a `Boolean` subclass for the given *object*.
     def self.[](object) : Boolean
@@ -19,21 +18,19 @@ module Novika
       Boolean[a == b]
     end
 
-    def self.desc(io : IO)
-      io << "a boolean"
+    def self.typedesc
+      "boolean"
     end
   end
 
   # Represents a truthy `Boolean`.
   struct True < Boolean
-    extend HasDesc
-
     def desc(io : IO)
       io << "boolean true"
     end
 
-    def self.desc(io : IO)
-      io << "boolean true"
+    def self.typedesc
+      "boolean"
     end
 
     def to_s(io)
@@ -46,14 +43,12 @@ module Novika
   # Represents a falsey `Boolean`. `False` is the only falsey
   # form in Novika.
   struct False < Boolean
-    extend HasDesc
-
     def desc(io : IO)
       io << "boolean false"
     end
 
-    def self.desc(io : IO)
-      io << "boolean false"
+    def self.typedesc
+      "boolean"
     end
 
     def sel(a, b)

--- a/src/novika/forms/builtin.cr
+++ b/src/novika/forms/builtin.cr
@@ -3,7 +3,6 @@ module Novika
   # `Proc`, for usage in the Novika-land.
   struct Builtin
     include Form
-    extend HasDesc
 
     # :nodoc:
     getter code : Engine ->
@@ -15,8 +14,8 @@ module Novika
       io << @desc
     end
 
-    def self.desc(io : IO)
-      io << "a builtin"
+    def self.typedesc
+      "builtin"
     end
 
     def open(engine : Engine)

--- a/src/novika/forms/decimal.cr
+++ b/src/novika/forms/decimal.cr
@@ -2,7 +2,6 @@ module Novika
   # A representation for decimal numbers inside Novika.
   struct Decimal
     include Form
-    extend HasDesc
 
     # Returns the underlying big decimal value.
     protected getter val : BigDecimal
@@ -18,8 +17,8 @@ module Novika
       io << "decimal number " << val
     end
 
-    def self.desc(io : IO)
-      io << "a decimal number"
+    def self.typedesc
+      "decimal"
     end
 
     # Returns whether this decimal is zero.

--- a/src/novika/forms/form.cr
+++ b/src/novika/forms/form.cr
@@ -1,23 +1,12 @@
 module Novika
-  # A form with a user-friendly description. Extenders should
-  # also include `Form`.
-  module HasDesc
-    # Appends a description of this form class to *io*.
-    abstract def desc(io : IO)
-
-    # Returns a description of this form class.
-    def desc : String
-      String.build { |io| desc(io) }
-    end
-  end
-
   # Form is an umbrella for words and blocks. Since some words
   # (like numbers, quotes) are just too different from words as
   # we know them, they have their own types directly subordinate
   # to Form.
+  #
+  # Make sure to override `self.typedesc` to avoid weird unrelated
+  # Crystal errors. Crystal breaks at class-level inheritance.
   module Form
-    extend HasDesc
-
     # Raises `Died` providing *details*.
     def die(details : String)
       raise Died.new(details)
@@ -26,11 +15,8 @@ module Novika
     # :nodoc:
     #
     # Dies of assertion failure with *other* type.
-    def afail(other)
-      l, r = self.class, other
-      ldesc = l.is_a?(HasDesc) ? l.desc : l.class
-      rdesc = r.is_a?(HasDesc) ? r.desc : r.class
-      die("bad type: #{ldesc}, expected: #{rdesc}")
+    def afail(other : T.class) forall T
+      die("bad type: #{self.class.typedesc}, expected: a #{T.typedesc}")
     end
 
     # Appends a string description of this form to *io*.
@@ -41,10 +27,6 @@ module Novika
     # Returns a string description of this form.
     def desc : String
       String.build { |io| desc(io) }
-    end
-
-    def self.desc(io : IO)
-      io << "a form"
     end
 
     # Selects either *a* or *b*. Novika defines `False` to be the

--- a/src/novika/forms/quote.cr
+++ b/src/novika/forms/quote.cr
@@ -17,7 +17,6 @@ module Novika
   # And yes, quotes do rely on the experimental grapheme API.
   module Quote
     include Form
-    extend HasDesc
 
     # Creates a quote variant from *string*.
     #
@@ -35,8 +34,8 @@ module Novika
       io << "a quote"
     end
 
-    def self.desc(io : IO)
-      io << "a quote"
+    def self.typedesc
+      "quote"
     end
 
     # Converts this quote variant to `String`.
@@ -143,6 +142,10 @@ module Novika
       @cached_count = @string.bytesize if ascii_only?
     end
 
+    def self.typedesc
+      "quote"
+    end
+
     protected def slice_at!(slicept : Int32, size : Int32) : {Quote, Quote}?
       return {
         # Fast path. Also, this string is ASCII only, then its
@@ -229,6 +232,10 @@ module Novika
     getter grapheme : String::Grapheme
 
     def initialize(@grapheme : String::Grapheme)
+    end
+
+    def self.typedesc
+      "quote"
     end
 
     def string : String

--- a/src/novika/forms/quote.cr
+++ b/src/novika/forms/quote.cr
@@ -31,7 +31,7 @@ module Novika
     end
 
     def desc(io : IO)
-      io << "a quote"
+      io << "quote '" << string << "'"
     end
 
     def self.typedesc

--- a/src/novika/forms/words.cr
+++ b/src/novika/forms/words.cr
@@ -30,7 +30,7 @@ module Novika
     end
 
     def desc(io : IO)
-      io << "a word named " << id
+      io << "word named '" << id << "'"
     end
 
     def self.typedesc
@@ -95,7 +95,7 @@ module Novika
     end
 
     def desc(io : IO)
-      io << "a quoted word named " << id
+      io << "quoted word '" << id << "'"
     end
 
     def self.typedesc

--- a/src/novika/forms/words.cr
+++ b/src/novika/forms/words.cr
@@ -16,7 +16,6 @@ module Novika
   # enclosing block.
   struct Word
     include Form
-    extend HasDesc
 
     # Death hook name.
     DIED = Word.new("*died")
@@ -34,8 +33,8 @@ module Novika
       io << "a word named " << id
     end
 
-    def self.desc(io : IO)
-      io << "a word"
+    def self.typedesc
+      "word"
     end
 
     def opened(engine : Engine) : self
@@ -88,7 +87,6 @@ module Novika
   # are peeled off like in an onion.
   struct QuotedWord
     include Form
-    extend HasDesc
 
     # Returns the underlying string id.
     getter id : String
@@ -100,8 +98,8 @@ module Novika
       io << "a quoted word named " << id
     end
 
-    def self.desc(io : IO)
-      io << "a quoted word"
+    def self.typedesc
+      "quoted word"
     end
 
     # "Peels" off a layer of quoting.

--- a/src/novika/packages/console.cr
+++ b/src/novika/packages/console.cr
@@ -7,6 +7,10 @@ require "termbox2" # TODO: remove when common color object exists
 
 struct Termbox::Color # TODO: remove when common color object exists
   include Novika::Form
+
+  def self.typedesc
+    "color"
+  end
 end
 
 # TODO: use same color as in Colors

--- a/src/novika/packages/impl/essential.cr
+++ b/src/novika/packages/impl/essential.cr
@@ -799,8 +799,50 @@ module Novika::Packages::Impl
         Boolean[!engine.stack.drop.assert(engine, Block).parent?].push(engine)
       end
 
-      target.at("desc", "( F -- Hq ): leaves the description of Form.") do |engine|
+      target.at("desc", <<-END
+      ( F -- Dq ): leaves the Description quote of the given Form.
+
+      >>> 100 desc
+      === 'a decimal number 100'
+
+      >>> 'foobar' desc
+      === 'a quote 'foobar''
+
+      >>> [ 1 2 3 ] desc
+      === 'a block'
+
+      >>> [ "I am a block" 1 2 3 ] desc
+      === 'I am a block'
+
+      >>> true desc
+      === 'a boolean true'
+      END
+      ) do |engine|
         quote = Quote.new(engine.stack.drop.desc)
+        quote.push(engine)
+      end
+
+      target.at("typedesc", <<-END
+      ( F -- Dq ): leaves the type Description quote of the
+       given Form.
+
+      >>> 100 typedesc
+      === 'decimal'
+
+      >>> 'foobar' typedesc
+      === 'quote'
+
+      >>> [ 1 2 3 ] typedesc
+      === 'block'
+
+      >>> [ "I am a block" 1 2 3 ] typedesc
+      === 'block'
+
+      >>> true typedesc
+      === 'boolean'
+      END
+      ) do |engine|
+        quote = Quote.new(engine.stack.drop.class.typedesc)
         quote.push(engine)
       end
     end

--- a/src/novika/packages/impl/essential.cr
+++ b/src/novika/packages/impl/essential.cr
@@ -803,10 +803,10 @@ module Novika::Packages::Impl
       ( F -- Dq ): leaves the Description quote of the given Form.
 
       >>> 100 desc
-      === 'a decimal number 100'
+      === 'decimal number 100'
 
       >>> 'foobar' desc
-      === 'a quote 'foobar''
+      === 'quote 'foobar''
 
       >>> [ 1 2 3 ] desc
       === 'a block'
@@ -815,7 +815,7 @@ module Novika::Packages::Impl
       === 'I am a block'
 
       >>> true desc
-      === 'a boolean true'
+      === 'boolean true'
       END
       ) do |engine|
         quote = Quote.new(engine.stack.drop.desc)

--- a/tests/bugs.nk
+++ b/tests/bugs.nk
@@ -78,3 +78,11 @@ describe 'Infinite recursion when word undefined inside word trap #8' [
     ] there [ trigger-my-own-trap 300 trigger-upper-trap 200 trigger-upper-trap2 100 ] assert=
   ]
 ]
+
+describe 'Invalid typedesc for abstract types/modules #30' [
+  it should 'die with proper typedescs' [
+    [ 'foo' asWord ] 'bad type: quote, expected: a word' assertDies
+    [ true asQuote ] 'bad type: boolean, expected: a quote' assertDies
+    [ false asQuote ] 'bad type: boolean, expected: a quote' assertDies
+  ]
+]

--- a/tests/essential.nk
+++ b/tests/essential.nk
@@ -1,3 +1,47 @@
+describe 'desc' [
+  it should 'leave correct descriptions for value forms' [
+    true desc 'boolean true' assert=
+    false desc 'boolean false' assert=
+    100 desc 'decimal number 100' assert=
+    100.5 desc 'decimal number 100.5' assert=
+    'hello world' desc 'quote \'hello world\'' assert=
+    #foo desc 'word named \'foo\'' assert=
+    ##foo desc 'quoted word \'foo\'' assert=
+    ###foo desc 'quoted word \'#foo\'' assert=
+  ]
+
+  it should 'leave correct descriptions for blocks' [
+    [ ] desc 'a block' assert=
+    [ "hello world" ] desc 'hello world' assert=
+    [ "" "" "" "hello world" ] desc 'hello world' assert=
+    [ "" "" 1 "hello world" 3 ] desc 'a block' assert=
+    [ "foo" [ "boo" ] "baa" ] desc 'foo' assert=
+  ]
+
+  it should 'leave correct descriptions for builtin' [
+    #+ here desc '( A B -- S ): leaves the Sum of two decimals.' assert=
+  ]
+]
+
+describe 'typedesc' [
+  it should 'leave correct descriptions for value forms' [
+    true typedesc 'boolean' assert=
+    false typedesc 'boolean' assert=
+    #+ here typedesc 'builtin' assert=
+    123 typedesc 'decimal' assert=
+    123.456 typedesc 'decimal' assert=
+    'hello world' typedesc 'quote' assert=
+    #foo typedesc 'word' assert=
+    ##foo typedesc 'quoted word' assert=
+  ]
+
+  it should 'leave correct descriptions for blocks' [
+    [ ] typedesc 'block' assert=
+    [ 1 2 3 ] typedesc 'block' assert=
+    [ "foobar" ] typedesc 'block' assert=
+  ]
+]
+
 describe 'asDecimal' [
   it dies 'when given quote' [ 'foo' asDecimal ]
   it dies 'when given word' [ #foo asDecimal ]


### PR DESCRIPTION
* Fixes major and minor `desc` bugs.
* Adds `typedesc`, a word which can be used to get the type description of a form.

Closes #30.