### PR TITLE
Fetch stack only once in feature implementations

### DIFF
--- a/src/novika/dict.cr
+++ b/src/novika/dict.cr
@@ -93,7 +93,9 @@ module Novika
     end
 
     # See the same method in `Form`.
-    delegate :push, to: form
+    def onto(block : Block)
+      form.onto(block)
+    end
 
     # Works just like `open`, but returns the result immediately.
     #
@@ -105,7 +107,7 @@ module Novika
 
     # :ditto:
     def open(engine : Engine) : Nil
-      push(engine)
+      onto(engine.stack)
 
       nil
     end

--- a/src/novika/engine.cr
+++ b/src/novika/engine.cr
@@ -177,7 +177,7 @@ module Novika
 
     # Same as `schedule(form, stack)`.
     def schedule!(form, stack)
-      form.push(stack)
+      form.onto(stack)
     end
 
     # Adds an instance of *form* block to the continuations

--- a/src/novika/features/disk.cr
+++ b/src/novika/features/disk.cr
@@ -42,53 +42,53 @@ module Novika::Features
       ( Pq -- true/false ): leaves whether Path quote exists
        on the disk.
       END
-      ) do |engine|
-        path = engine.stack.drop.assert(engine, Quote)
-        has?(engine, path).push(engine)
+      ) do |engine, stack|
+        path = stack.drop.assert(engine, Quote)
+        has?(engine, path).onto(stack)
       end
 
       target.at("disk:canRead?", <<-END
       ( Pq -- true/false ): leaves whether Path quote exists
        and is readable.
       END
-      ) do |engine|
-        path = engine.stack.drop.assert(engine, Quote)
-        can_read?(engine, path).push(engine)
+      ) do |engine, stack|
+        path = stack.drop.assert(engine, Quote)
+        can_read?(engine, path).onto(stack)
       end
 
       target.at("disk:hasDir?", <<-END
       ( Pq -- true/false ): leaves whether Path quote exists
        and points to a directory.
       END
-      ) do |engine|
-        path = engine.stack.drop.assert(engine, Quote)
-        has_dir?(engine, path).push(engine)
+      ) do |engine, stack|
+        path = stack.drop.assert(engine, Quote)
+        has_dir?(engine, path).onto(stack)
       end
 
       target.at("disk:hasFile?", <<-END
       ( Pq -- true/false ): leaves whether Path quote exists
        and points to a file.
       END
-      ) do |engine|
-        path = engine.stack.drop.assert(engine, Quote)
-        has_file?(engine, path).push(engine)
+      ) do |engine, stack|
+        path = stack.drop.assert(engine, Quote)
+        has_file?(engine, path).onto(stack)
       end
 
       target.at("disk:hasSymlink?", <<-END
       ( Pq -- true/false ): leaves whether Path quote exists
        and points to a symlink.
       END
-      ) do |engine|
-        path = engine.stack.drop.assert(engine, Quote)
-        has_symlink?(engine, path).push(engine)
+      ) do |engine, stack|
+        path = stack.drop.assert(engine, Quote)
+        has_symlink?(engine, path).onto(stack)
       end
 
       target.at("disk:touch", <<-END
       ( P -- ): creates an empty file at Path. Does nothing
        if Path already exists.
       END
-      ) do |engine|
-        path = engine.stack.drop.assert(engine, Quote)
+      ) do |engine, stack|
+        path = stack.drop.assert(engine, Quote)
         touch(engine, path)
       end
 
@@ -96,10 +96,10 @@ module Novika::Features
       ( F -- C ): reads and leaves the Contents of File. Dies
        if there is no File.
       END
-      ) do |engine|
-        path = engine.stack.drop.assert(engine, Quote)
+      ) do |engine, stack|
+        path = stack.drop.assert(engine, Quote)
         path.die("no file at path") unless contents = read?(engine, path)
-        contents.push(engine)
+        contents.onto(stack)
       end
     end
   end

--- a/src/novika/features/frontend.cr
+++ b/src/novika/features/frontend.cr
@@ -24,7 +24,7 @@ module Novika::Features
       target.at("novika:version", <<-END
       ( -- Vq ): leaves Version of the frontend as a quote.
       END
-      ) { |engine| version(engine).push(engine) }
+      ) { |engine, stack| version(engine).onto(stack) }
 
       target.at("novika:features", <<-END
       ( -- Fb ): lists the ids of features provided by the
@@ -33,7 +33,7 @@ module Novika::Features
       >>> novika:features
       === [ 'essential' 'colors' 'console' | ] (yours may differ)
       END
-      ) { |engine| features(engine).push(engine) }
+      ) { |engine, stack| features(engine).onto(stack) }
     end
   end
 end

--- a/src/novika/features/impl/colors.cr
+++ b/src/novika/features/impl/colors.cr
@@ -22,11 +22,11 @@ module Novika::Features::Impl
       >>> 36 255 255 rgb
       === rgb(36, 255 ,255)
       END
-      ) do |engine|
-        b = engine.stack.drop.assert(engine, Decimal).in(0..255).posint
-        g = engine.stack.drop.assert(engine, Decimal).in(0..255).posint
-        r = engine.stack.drop.assert(engine, Decimal).in(0..255).posint
-        Color.rgb(r, g, b).push(engine)
+      ) do |engine, stack|
+        b = stack.drop.assert(engine, Decimal).in(0..255).posint
+        g = stack.drop.assert(engine, Decimal).in(0..255).posint
+        r = stack.drop.assert(engine, Decimal).in(0..255).posint
+        Color.rgb(r, g, b).onto(stack)
       end
 
       target.at("getRGB", <<-END
@@ -38,12 +38,12 @@ module Novika::Features::Impl
       >>> getRGB
       === 0 25 3
       END
-      ) do |engine|
-        color = engine.stack.drop.assert(engine, Color)
+      ) do |engine, stack|
+        color = stack.drop.assert(engine, Color)
         r, g, b = color.rgb
-        r.push(engine)
-        g.push(engine)
-        b.push(engine)
+        r.onto(stack)
+        g.onto(stack)
+        b.onto(stack)
       end
 
       target.at("hsl", <<-END
@@ -57,11 +57,11 @@ module Novika::Features::Impl
       >>> 206 35 46 hsl
       === rgb(76, 123, 158)
       END
-      ) do |engine|
-        l = engine.stack.drop.assert(engine, Decimal).in(0..100).posint
-        s = engine.stack.drop.assert(engine, Decimal).in(0..100).posint
-        h = engine.stack.drop.assert(engine, Decimal).in(0..360).posint
-        Color.hsl(h, s, l).push(engine)
+      ) do |engine, stack|
+        l = stack.drop.assert(engine, Decimal).in(0..100).posint
+        s = stack.drop.assert(engine, Decimal).in(0..100).posint
+        h = stack.drop.assert(engine, Decimal).in(0..360).posint
+        Color.hsl(h, s, l).onto(stack)
       end
 
       target.at("getHSL", <<-END
@@ -73,12 +73,12 @@ module Novika::Features::Impl
       >>> getHSL
       === 206 35 46
       END
-      ) do |engine|
-        color = engine.stack.drop.assert(engine, Color)
+      ) do |engine, stack|
+        color = stack.drop.assert(engine, Color)
         h, s, l = color.hsl
-        h.push(engine)
-        s.push(engine)
-        l.push(engine)
+        h.onto(stack)
+        s.onto(stack)
+        l.onto(stack)
       end
 
       target.at("hsv", <<-END
@@ -92,11 +92,11 @@ module Novika::Features::Impl
       >>> 120 100 100 hsv
       === rgb(0, 255, 0)
       END
-      ) do |engine|
-        v = engine.stack.drop.assert(engine, Decimal).in(0..100).posint
-        s = engine.stack.drop.assert(engine, Decimal).in(0..100).posint
-        h = engine.stack.drop.assert(engine, Decimal).in(0..360).posint
-        Color.hsv(h, s, v).push(engine)
+      ) do |engine, stack|
+        v = stack.drop.assert(engine, Decimal).in(0..100).posint
+        s = stack.drop.assert(engine, Decimal).in(0..100).posint
+        h = stack.drop.assert(engine, Decimal).in(0..360).posint
+        Color.hsv(h, s, v).onto(stack)
       end
 
       target.at("getHSV", <<-END
@@ -108,12 +108,12 @@ module Novika::Features::Impl
       >>> getHSV
       === 180 100 50
       END
-      ) do |engine|
-        color = engine.stack.drop.assert(engine, Color)
+      ) do |engine, stack|
+        color = stack.drop.assert(engine, Color)
         h, s, v = color.hsv
-        h.push(engine)
-        s.push(engine)
-        v.push(engine)
+        h.onto(stack)
+        s.onto(stack)
+        v.onto(stack)
       end
 
       target.at("lch", <<-END
@@ -174,11 +174,11 @@ module Novika::Features::Impl
       that the conversion method used by this word and `getLCH`
       is lossy sometimes.
       END
-      ) do |engine|
-        h = engine.stack.drop.assert(engine, Decimal).in(0..360).posint
-        c = engine.stack.drop.assert(engine, Decimal).in(0..132).posint
-        l = engine.stack.drop.assert(engine, Decimal).in(0..100).posint
-        Color.lch(l, c, h).push(engine)
+      ) do |engine, stack|
+        h = stack.drop.assert(engine, Decimal).in(0..360).posint
+        c = stack.drop.assert(engine, Decimal).in(0..132).posint
+        l = stack.drop.assert(engine, Decimal).in(0..100).posint
+        Color.lch(l, c, h).onto(stack)
       end
 
       target.at("getLCH", <<-END
@@ -198,12 +198,12 @@ module Novika::Features::Impl
        shift on chroma changes, 26 -> 25"
       === 74 41 25
       END
-      ) do |engine|
-        color = engine.stack.drop.assert(engine, Color)
+      ) do |engine, stack|
+        color = stack.drop.assert(engine, Color)
         l, c, h = color.lch
-        l.push(engine)
-        c.push(engine)
-        h.push(engine)
+        l.onto(stack)
+        c.onto(stack)
+        h.onto(stack)
       end
 
       target.at("withAlpha", <<-END
@@ -215,11 +215,11 @@ module Novika::Features::Impl
       >>> 100 withAlpha
       === rgba(0, 25, 3, 100)
       END
-      ) do |engine|
-        alpha = engine.stack.drop.assert(engine, Decimal).in(0..255).posint
-        color = engine.stack.drop.assert(engine, Color)
+      ) do |engine, stack|
+        alpha = stack.drop.assert(engine, Decimal).in(0..255).posint
+        color = stack.drop.assert(engine, Color)
         color.a = alpha
-        color.push(engine)
+        color.onto(stack)
       end
 
       target.at("getAlpha", <<-END
@@ -237,9 +237,9 @@ module Novika::Features::Impl
       >>> getAlpha
       === 100
       END
-      ) do |engine|
-        color = engine.stack.drop.assert(engine, Color)
-        color.a.push(engine)
+      ) do |engine, stack|
+        color = stack.drop.assert(engine, Color)
+        color.a.onto(stack)
       end
 
       target.at("fromPalette", <<-END
@@ -263,16 +263,16 @@ module Novika::Features::Impl
       >>> 74 20 140 rgb pal fromPalette "very dark purple"
       === rgb(255, 0, 0)
       END
-      ) do |engine|
-        palette = engine.stack.drop.assert(engine, Block)
-        color = engine.stack.drop.assert(engine, Color)
+      ) do |engine, stack|
+        palette = stack.drop.assert(engine, Block)
+        color = stack.drop.assert(engine, Color)
 
         colors = [] of Color
         palette.each do |pcolor|
           colors << pcolor.assert(engine, Color)
         end
 
-        color.closest(colors).push(engine)
+        color.closest(colors).onto(stack)
       end
     end
   end

--- a/src/novika/features/ink.cr
+++ b/src/novika/features/ink.cr
@@ -48,27 +48,27 @@ module Novika::Features
       ( C -- ): pushes Color form onto the echo foreground
        color stack.
       END
-      ) do |engine|
-        fg << engine.stack.drop.assert(engine, Color)
+      ) do |engine, stack|
+        fg << stack.drop.assert(engine, Color)
       end
 
       target.at("withEchoBg", <<-END
       ( C -- ): pushes Color form onto the echo background
        color stack.
       END
-      ) do |engine|
-        bg << engine.stack.drop.assert(engine, Color)
+      ) do |engine, stack|
+        bg << stack.drop.assert(engine, Color)
       end
 
       target.at("dropEchoFg", <<-END
       ( -- ): drops a color from the echo foreground color stack.
       END
-      ) { |engine| fg.pop? }
+      ) { |engine, stack| fg.pop? }
 
       target.at("dropEchoFg", <<-END
       ( -- ): drops a color from the echo background color stack.
       END
-      ) { |engine| bg.pop? }
+      ) { |engine, stack| bg.pop? }
 
       target.at("withColorAppendEcho", <<-END
       ( F -- ): appends Form with last color from the echo
@@ -85,8 +85,8 @@ module Novika::Features
       If you want more cross-platform control over colors (and
       pretty much everything else), take a look at feature console.
       END
-      ) do |engine|
-        form = engine.stack.drop
+      ) do |engine, stack|
+        form = stack.drop
 
         if enabled? && (fg.last? || bg.last?)
           # If color output is enabled and either foreground

--- a/src/novika/features/system.cr
+++ b/src/novika/features/system.cr
@@ -46,7 +46,7 @@ module Novika::Features
       ( F -- ): enquotes and appends Form to the standard
        output stream.
       END
-      ) { |engine| append_echo(engine, engine.stack.drop) }
+      ) { |engine, stack| append_echo(engine, stack.drop) }
 
       target.at("readLine", <<-END
       ( Pf -- Aq Sb ): enquotes and prints Prompt form to the
@@ -60,10 +60,10 @@ module Novika::Features
       What is your name? John Doe ⏎
       John Doe
       END
-      ) do |engine|
-        answer, status = readline(engine, engine.stack.drop)
-        answer.push(engine)
-        status.push(engine)
+      ) do |engine, stack|
+        answer, status = readline(engine, stack.drop)
+        answer.onto(stack)
+        status.onto(stack)
       end
 
       target.at("reportError", <<-END
@@ -73,8 +73,8 @@ module Novika::Features
       You can obtain an error object by, e.g., catching it
       in `*died`.
       END
-      ) do |engine|
-        error = engine.stack.drop.assert(engine, Died)
+      ) do |engine, stack|
+        error = stack.drop.assert(engine, Died)
 
         report_error(engine, error)
       end
@@ -97,13 +97,13 @@ module Novika::Features
       >>> end start -
       === 20 (approximately)
       END
-      ) { |engine| monotonic(engine).push(engine) }
+      ) { |engine, stack| monotonic(engine).onto(stack) }
 
       target.at("nap", <<-END
       ( Nms -- ): sleeps for N decimal milliseconds.
       END
-      ) do |engine|
-        millis = engine.stack.drop.assert(engine, Decimal)
+      ) do |engine, stack|
+        millis = stack.drop.assert(engine, Decimal)
 
         nap(engine, millis)
       end

--- a/src/novika/forms/block.cr
+++ b/src/novika/forms/block.cr
@@ -274,12 +274,12 @@ module Novika
 
     # Makes an `OpenEntry` called *name* for *code* wrapped
     # in `Builtin`.
-    def at(name : Word, desc = "a builtin", &code : Engine ->) : self
+    def at(name : Word, desc = "a builtin", &code : Engine, Block ->) : self
       at name, OpenEntry.new Builtin.new(desc, code)
     end
 
     # :ditto:
-    def at(name : String, desc = "a builtin", &code : Engine ->) : self
+    def at(name : String, desc = "a builtin", &code : Engine, Block ->) : self
       at Word.new(name), OpenEntry.new Builtin.new(desc, code)
     end
 

--- a/src/novika/forms/builtin.cr
+++ b/src/novika/forms/builtin.cr
@@ -5,7 +5,7 @@ module Novika
     include Form
 
     # :nodoc:
-    getter code : Engine ->
+    getter code : Engine, Block ->
 
     def initialize(@desc : String, @code)
     end
@@ -19,7 +19,7 @@ module Novika
     end
 
     def open(engine : Engine)
-      code.call(engine)
+      code.call(engine, engine.stack)
     end
 
     def val(engine : Engine? = nil, stack : Block? = nil)

--- a/src/novika/forms/form.cr
+++ b/src/novika/forms/form.cr
@@ -42,17 +42,12 @@ module Novika
 
     # Reacts to this form's enclosing block being opened in *engine*.
     def opened(engine : Engine) : self
-      push(engine)
+      onto(engine.stack)
     end
 
     # Adds this form to *block*.
-    def push(block : Block) : self
+    def onto(block : Block) : self
       tap { block.add(self) }
-    end
-
-    # Pushes this form onto *engine*'s active stack.
-    def push(engine : Engine) : self
-      push(engine.stack)
     end
 
     # Returns the result of opening this form with *engine*.

--- a/src/novika/forms/words.cr
+++ b/src/novika/forms/words.cr
@@ -114,7 +114,7 @@ module Novika
     end
 
     def val(engine : Engine? = nil, stack : Block? = nil)
-      peel.push(stack || Block.new)
+      peel.onto(stack || Block.new)
     end
 
     # Converts this quoted word to `Word`.
@@ -123,7 +123,7 @@ module Novika
     end
 
     def opened(engine) : self
-      tap { peel.push(engine) }
+      tap { peel.onto(engine.stack) }
     end
 
     def to_s(io)


### PR DESCRIPTION
* Rename `Form#push(...)` to `Form#onto(...)`
* Get rid of `Form#onto(engine)` as it makes little sense when read aloud

Improves performance by about 5-10% relative to pre-branch for tests, `100_000 times: []`, etc. Otherwise very small, mostly unnoticeable improvement. Does reduce the number of index lookups though: the sheer amount of them is so massive it does make a tiny, but difference still.