### PR TITLE
Handwrite `Block#slurp`

### DIFF
--- a/json-docs.nk
+++ b/json-docs.nk
@@ -13,7 +13,6 @@ this $: _toplevel
     '\n'   '\\n' replaceAll
     '\t'   '\\t' replaceAll
     '"'    '\\"' replaceAll
-    '\\\'' '\''  replaceAll
   $: quote
 
   [ '"' quote '"' ] ~*

--- a/src/novika.cr
+++ b/src/novika.cr
@@ -4,6 +4,8 @@ require "colorize"
 
 # Order is important!
 require "./novika/forms/form"
+require "./novika/scissors"
+require "./novika/classifier"
 require "./novika/error"
 require "./novika/tape"
 require "./novika/dict"

--- a/src/novika/classifier.cr
+++ b/src/novika/classifier.cr
@@ -1,0 +1,277 @@
+# TODO: move 0xs to constants
+
+# `Classifier` brings *unclassified forms* to life.
+#
+# `Classifier` assigns types to fragments of Novika code: this
+# fragment is a decimal, this one is a word, this one is a quote.
+# Fragments are given to `Classifier` by `Scissors`, a small
+# object specializing in this very thing: cutting a big blob
+# of Novika code into fragments.
+#
+# `Scissors` and `Classifier` are designed to work in tandem.
+# Separating one from the other is possible and will work, but
+# is not recommended unless you read the source code of both.
+struct Novika::Classifier
+  # Returns the source code byte pointer used by this classifier.
+  getter bytes
+
+  # Returns the block used by this classifier.
+  getter block
+
+  # Initializes a classifier from the given *source* string and
+  # Novika *Block*.
+  def initialize(source : String, block : Novika::Block)
+    initialize(source.to_unsafe, block)
+  end
+
+  # :nodoc:
+  def initialize(@bytes : UInt8*, @ceiling : Novika::Block)
+    @block = ceiling
+  end
+
+  private delegate :add, to: block
+
+  # Creates an empty child block, and makes it the current block.
+  private def nest
+    @block = block.class.new(block)
+  end
+
+  # Adds the current block onto its parent's tape, and makes
+  # that parent the current block.
+  private def unnest
+    @block.die("mismatched ']' in block") if @ceiling.same?(@block)
+    @block = block.parent.tap &.add(block)
+  end
+
+  # Takes a byte slice starting at *start*, and of *count*
+  # bytes in size; wraps it in a string without any kind of
+  # interpretation. Returns the resulting string.
+  private def build_raw(start, count)
+    String.build do |io|
+      start.upto(start + count - 1) do |index|
+        io.write_byte(@bytes[index])
+      end
+    end
+  end
+
+  # Takes a byte slice starting at *start*, and of *count*
+  # bytes in size, and wraps it in a string.
+  #
+  # Bytes in the slice are interpreted as quote contents.
+  # For example, escape sequences are evaluated (unescaped).
+  # Returns the resulting string.
+  #
+  # Assumes the quote is properly terminated.
+  private def build_quote(start, count)
+    String.build do |io|
+      b = start
+      e = start + count - 1
+
+      while b <= e
+        byte = bytes[b]
+
+        # Advance after the byte.
+        b += 1
+
+        unless byte == 0x5c # '\\'
+          io.write_byte(byte)
+          next
+        end
+
+        case bytes[b]
+        when 0x5c then io << '\\'
+        when 0x27 then io << '\''
+        when 'n'  then io << '\n'
+        when 't'  then io << '\t'
+        when 'r'  then io << '\r'
+        when 'v'  then io << '\v'
+        when 'e'  then io << '\e'
+        else
+          # Leave the "escape sequence" as-is.
+          io.write_byte(byte)
+          next
+        end
+
+        # Advance after the escaped character byte.
+        b += 1
+      end
+    end
+  end
+
+  # Similar to `build_quote` but for comments.
+  #
+  # Assumes the comment is properly terminated.
+  private def build_comment(start, count)
+    String.build do |io|
+      b = start
+      e = start + count - 1
+
+      while b <= e
+        byte = bytes[b]
+        b += 1
+
+        unless byte == 0x5c # '\\'
+          io.write_byte(byte)
+          next
+        end
+
+        case bytes[b]
+        when 0x5c then io << '\\'
+        when 0x22 then io << '"'
+        else
+          # Leave the "escape sequence" as-is.
+          io.write_byte(byte)
+          next
+        end
+
+        b += 1
+      end
+    end
+  end
+
+  # Returns whether *byte* is a decimal digit 0-9.
+  @[AlwaysInline]
+  private def digit?(byte : UInt8)
+    byte.in?(0x30..0x39)
+  end
+
+  # Returns whether the subrange `b..e` is an integer decimal.
+  #
+  # *sign* toggles optional sign parsing.
+  #
+  # **Beware**: returns true if `b == e`. You should handle
+  # your "empty" cases yourself.
+  private def decimal?(b, e, sign = false)
+    b.upto(e) do |index|
+      byte = @bytes[index]
+
+      # * : '0'..'9'
+      next if digit?(byte)
+
+      case index
+      when b
+        # 0 : '+', '-'
+        return false unless sign
+        return false unless byte.in?(0x2b, 0x2d)
+
+        # For '+', '-', also make sure the following is true:
+        #
+        # '+'|'-'    '0'..'9'
+        #
+        return false unless index < e && digit?(@bytes[index + 1])
+      when ..e - 1
+        # 1..-2 : '_'
+        return false unless byte == 0x5f
+      else
+        return false
+      end
+    end
+
+    true
+  end
+
+  # Classifies the subrange starting at byte index *start*,
+  # and *count* bytes long. *dot* is the byte index of `'.'`.
+  #
+  # These three arguments are assumed to come from `Scissors#cut`.
+  #
+  # This method does practically no bounds checks, is unsafe
+  # and must be worked with carefully.
+  def classify(start, count, dot) : Nil
+    return if count.zero?
+
+    byte = @bytes[start]
+
+    case byte
+    when 0x5b
+      # If start is '[', then this is a block open.
+      nest
+    when 0x5d
+      # If start is ']', then this is a block close.
+      unnest
+    when 0x23
+      # If start is '#', and count > 1, then this is a quoted
+      # word. Otherwise, this is the word "#".
+      if count > 1
+        # Omit the number/pound/whatever sign.
+        add Novika::QuotedWord.new(build_raw(start + 1, count - 1))
+      else
+        add Novika::Word.new("#")
+      end
+    when 0x27
+      # If start is '\'', then this is a quote. Omit the
+      # quotes though.
+      #
+      # Here we rely on Scissors' guarantee that quote is
+      # properly terminated (i.e., there is a closing ').
+      add Novika::Quote.new(build_quote(start + 1, count - 2))
+    when 0x22
+      # If start is '"', add a comment to the current block
+      # if it is empty and doesn't already have one.
+      #
+      # Here we also rely on Scissors' guarantee that the
+      # comment is properly terminated.
+      return if block.has_comment?
+      return unless block.count.zero?
+
+      # Do not forget to omit the quotes.
+      block.describe_with?(build_comment(start + 1, count - 2))
+    else
+      e = start + count - 1
+
+      unless dot
+        # If dot = nil and start..end is an optionally signed
+        # decimal, then this is a decimal. Otherwise, this is
+        # a word.
+        frag = build_raw(start, count)
+        if decimal?(start, e, sign: true)
+          add Novika::Decimal.new(frag)
+        else
+          add Novika::Word.new(frag)
+        end
+        return
+      end
+
+      if start < dot < e && decimal?(start, dot - 1, sign: true) && decimal?(dot + 1, e)
+        # If dot = I, I.in(start..end) (since e.g. `.2`, `2.`, and
+        # derived are *invalid* decimals in Novika), start...I is an
+        # optionally signed decimal, and I + 1..end is an unsigned
+        # decimal, then this is a decimal.
+        add Novika::Decimal.new(build_raw(start, count))
+      else
+        # Otherwise, recurse on start...I and I + 1..end. Then
+        # this is the word `.`.
+        #
+        # By definition, `dot` is the first dot in the unclassified
+        # form. Therefore, there is no dot left of it; so don't even
+        # look there.
+        classify(start, dot - start, dot: nil)
+        add Novika::Word.new(".")
+        classify(dot + 1, e - dot)
+      end
+    end
+  end
+
+  # Classifies the subrange starting at byte index *start*,
+  # and *count* bytes long.
+  def classify(start, count)
+    dot = nil
+    start.upto(start + count - 1) do |index|
+      dot = index if @bytes[index] == 0x2e # '.'
+    end
+    classify(start, count, dot)
+  end
+
+  # Ends classification. Makes sure the ceiling block is closed.
+  def end
+    @block.die("missing ']'") unless @ceiling.same?(@block)
+  end
+
+  # Shorthand for `initialize` followed by `end`. Yields
+  # the instance.
+  def self.for(source : String, block : Novika::Block)
+    classifier = new(source, block)
+    yield classifier
+    classifier.end
+  end
+end

--- a/src/novika/forms/block.cr
+++ b/src/novika/forms/block.cr
@@ -114,6 +114,11 @@ module Novika
       "block"
     end
 
+    # Returns whether this block has a comment.
+    def has_comment? : Bool
+      !!@comment.try { |it| !it.empty? }
+    end
+
     # Returns this block's comment, or nil if the comment was
     # not defined or is empty.
     protected def comment? : String?

--- a/src/novika/forms/block.cr
+++ b/src/novika/forms/block.cr
@@ -1,16 +1,4 @@
 module Novika
-  # The regex that splits Novika source code into morphemes.
-  MORPHEMES = /
-      (?<num> [-+]?\d(?:[\d_]*\d)?(?:\.\d(?:[\d_]*\d)?)?) (?=\.|\s+|\[|\]|$)
-    | (?<bb> \[)
-    | (?<be> \])
-    | (?<qword> \#[^"'\s\[\]]+)
-    | (?<word> [^"'\s\.\[\]]+|\.)
-    |'(?<quote> (?:[^'\\]|\\[\\ntrve'])*)'
-    |"(?<comment> (?:[^"\\]|\\.)*)"
-    |\s+
-  /x
-
   # Regex that can be used to search for a pattern in `Block`
   # comments. Perfer `Form#effect` over matching by hand.
   EFFECT_PATTERN = /^(\(\s+(?:[^\(\)]*)\--(?:[^\(\)]*)\s+\)):/
@@ -178,42 +166,11 @@ module Novika
     # Parses all forms in string *source*, and adds them to
     # this block.
     def slurp(source : String) : self
-      start, block = 0, self
-
-      while MORPHEMES.match(source, pos: start)
-        if match = $~["num"]?
-          block.add Decimal.new(match)
-        elsif match = $~["word"]?
-          block.add Word.new(match)
-        elsif match = $~["qword"]?
-          block.add QuotedWord.new(match.lchop)
-        elsif match = $~["quote"]?
-          match = match
-            .gsub(/(?<!\\)\\'/, '\'')
-            .gsub(/(?<!\\)\\n/, '\n')
-            .gsub(/(?<!\\)\\t/, '\t')
-            .gsub(/(?<!\\)\\r/, '\r')
-            .gsub(/(?<!\\)\\v/, '\v')
-            .gsub(/(?<!\\)\\e/, '\e')
-            .gsub(/\\\\/, '\\')
-          block.add Quote.new(match)
-        elsif match = $~["comment"]?
-          if block.tape.empty?
-            match = match
-              .gsub(/(?<!\\)\\"/, '"')
-              .gsub(/\\\\/, '\\')
-            block.describe_with?(dedent match)
-          end
-        elsif $~["bb"]?
-          block = self.class.new(block)
-        elsif $~["be"]?
-          block = block.parent.tap &.add(block)
+      Classifier.for(source, block: self) do |classifier|
+        Scissors.cut(source) do |start, count, dot|
+          classifier.classify(start, count, dot)
         end
-
-        start += $0.size
       end
-
-      block.die("missing closing bracket") unless same?(block)
 
       self
     end

--- a/src/novika/scissors.cr
+++ b/src/novika/scissors.cr
@@ -1,0 +1,140 @@
+# Scissors deal with cutting a source string into fragments,
+# known as *unclassified forms*. They are then fed to an
+# instance of `Classifier`, which determines whether an
+# unclassified form is actually a decimal, quoted word,
+# quote, etc. You can think of Scissors as a fancy split-
+# by-whitespace.
+#
+# `Scissors` and `Classifier` are designed to work in tandem.
+# Separating one from the other is possible and will work, but
+# is not recommended unless you read the source code of both.
+struct Novika::Scissors
+  private getter length = 0
+
+  def initialize(source : String)
+    @dot = nil
+    @reader = Char::Reader.new(source)
+  end
+
+  # Introduces a cutpoint (slicepoint): resets the length.
+  @[AlwaysInline]
+  private def cut
+    @dot = nil
+    @length = 0
+  end
+
+  # Grows the length.
+  @[AlwaysInline]
+  private def grow
+    @length += @reader.current_char_width
+  end
+
+  # Returns whether the reader is at the end of the source code.
+  @[AlwaysInline]
+  private def at_end?
+    !@reader.has_next?
+  end
+
+  # Returns the current character, raises if none.
+  @[AlwaysInline]
+  private def chr
+    @reader.current_char
+  end
+
+  # Returns the byte index of the current slicepoint (i. e. start
+  # of current form).
+  @[AlwaysInline]
+  private def start
+    @reader.pos - length
+  end
+
+  # Advances the reader to the next character, raises if none.
+  @[AlwaysInline]
+  private def advance
+    @reader.next_char
+  end
+
+  # Advances, and grows the length; in other words, advances
+  # *through* the current character.
+  @[AlwaysInline]
+  private def thru
+    advance
+    grow
+  end
+
+  # Advances through (see `thru`) until an instance of *endswith*
+  # which is *not* preceded by *escape* is found.
+  #
+  # Raises if reached the end without matching *endswith*.
+  @[AlwaysInline]
+  private def thru(endswith : Char, escape = '\\')
+    until at_end?
+      thru if chr == escape
+      thru
+      if chr == endswith
+        thru
+        return
+      end
+    end
+
+    raise Novika::Error.new("unterminated excerpt: no matching ｢#{endswith}｣")
+  end
+
+  # Cuts the source string into a series of *unclassified forms*;
+  # yields start byte index, byte length, and first dot `'.'` byte
+  # index of each to the block.
+  #
+  # Dot byte index is yielded to save an O(N) search, which would
+  # be otherwise required since '.' is handled specially by several
+  # forms in Novika.
+  def each
+    until at_end?
+      case it = chr
+      when .ascii_whitespace?
+        # In Novika, whitespace acts as the primary separator between
+        # forms. It is otherwise skipped.
+        yield start, length, @dot unless length.zero?
+        cut
+        advance
+      when '\'', '"'
+        # Quotes and comments act like a separator, too, mainly because
+        # they can contain other separators. Note that comments are not
+        # ignored here; they are ignored by the block rather than here,
+        # because their content still could be of relevance.
+        yield start, length, @dot unless length.zero?
+        cut
+        thru endswith: it
+        yield start, length, @dot
+        cut
+      when '[', ']'
+        # Block brackets [] are special in that they don't require any
+        # separator before or after; instead, they themselves are separators,
+        # in this sense much like quotes, but for a different reason.
+        yield start, length, @dot unless length.zero?
+        cut
+        thru
+        yield start, length, @dot
+        cut
+      when '.'
+        # Remember where the first dot was. This is nil-led
+        # in `cut`.
+        @dot ||= @reader.pos
+        thru
+      else
+        # Everything else is simply skipped over, and, when a separator
+        # is found, yielded to the block. Could be a word, could be a
+        # decimal; we don't have the authority to decide that here.
+        # Instead, Classifier makes such kinds of decisions.
+        thru
+      end
+    end
+    yield start, length, @dot unless length.zero?
+  end
+
+  # Cuts *source* into a series of *unclassified forms*; yields
+  # start byte index and byte length of each to the block.
+  def self.cut(source : String, & : Int32, Int32, Int32? ->)
+    slicer = new(source)
+    slicer.each { |start, count, dot| yield start, count, dot }
+  end
+end


### PR DESCRIPTION
Two components, *scissors* and *classifier*.

* Scissors deal with cutting a source string into fragments, known as *unclassified forms*. They are then fed to an instance of `Classifier`, which determines whether an unclassified form is actually a decimal, quoted word, quote, etc. You can think of Scissors as a fancy split-by-whitespace.

* `Classifier` assigns types to fragments of Novika code: this fragment is a decimal, this one is a word, this one is a quote. Fragments are given to `Classifier` by `Scissors`, a small object specializing in this very thing: cutting a big blob of Novika code into fragments.

## Performance

300x-ish improvement.

Regex implementation starts being super-slow on larger files. A ~7000 line file holding all Novika code from this repo is slurped in ±2s. I said Regexes were an overkill! And I didn't really write them with performance in mind, too.

Now the ~7000 line file it's slurped in ±7ms with minimal (1%-ish) deviation. The frontend feels snappier.

## How to improve it

I wanted the thing to be sub-millisecond, though. And `Scissors` already are (883.24µs with 0.3% deviation)! Cutting Scissors down even more is hardly imaginable: 158 468 characters in that sample file I was talking about leave about 5ns per character, which I believe to be very close to the bottom. It could be possible to squeeze 1-2ns though, but I'm afraid this'll require writing some assembly. 

Optimizing `Classifier` itself would be dumb, because it's also very fast and there's very little *classifier* code there.

Optimizing form initializers is the best way to get close to 1ms: do not parse decimals or quotes until they're needed; use `StringView`s when referring to source code (e.g. in quotes, words, quoted words etc), rather than `String.build`ing or byte slicing a whole new copy.

I'd speculate this'll bring the thing *very* close to 1ms, and reduce memory usage, perhaps by a few megs.

Closes #54.