### PR TITLE
Use dunder `__typeDesc__` instead of `__as[TypeDesc]__` in conversion words/metawords

### DIFF
--- a/env/core/fs/file.nk
+++ b/env/core/fs/file.nk
@@ -26,7 +26,7 @@
     available? => [ asQuote disk:read enclose block hydrate ]
   ] @: contents:
 
-  [ '<File at: ' asQuote stitch '>' stitch ] @: __asQuote__
+  [ '<File at: ' asQuote stitch '>' stitch ] @: __quote__
 
   this
 ] @: file

--- a/env/core/fs/file.nk
+++ b/env/core/fs/file.nk
@@ -26,7 +26,7 @@
     available? => [ asQuote disk:read enclose block hydrate ]
   ] @: contents:
 
-  [ '<File at: ' asQuote stitch '>' stitch ] @: *asQuote
+  [ '<File at: ' asQuote stitch '>' stitch ] @: __asQuote__
 
   this
 ] @: file

--- a/env/core/fs/path.nk
+++ b/env/core/fs/path.nk
@@ -23,7 +23,7 @@
     pathQuote disk:hasSymlink?
   ] @: symlink?
 
-  [ '<Path: ' pathQuote stitch '>' stitch ] @: *asQuote
+  [ '<Path: ' pathQuote stitch '>' stitch ] @: __asQuote__
 
   this
 ] @: path

--- a/env/core/fs/path.nk
+++ b/env/core/fs/path.nk
@@ -23,7 +23,7 @@
     pathQuote disk:hasSymlink?
   ] @: symlink?
 
-  [ '<Path: ' pathQuote stitch '>' stitch ] @: __asQuote__
+  [ '<Path: ' pathQuote stitch '>' stitch ] @: __quote__
 
   this
 ] @: path

--- a/env/core/test/test.nk
+++ b/env/core/test/test.nk
@@ -304,7 +304,7 @@ orphan $: _groups
         _deathHandlers cherry drop
       ] @: deathHandlerDo:
 
-      block #*died [
+      block #__died__ [
         "Catches unhandled deaths in test block and opens the
          top block in `_deathHandlers`."
         _deathHandlers top open
@@ -356,7 +356,7 @@ orphan $: _groups
       false $: died?
       [ ] $: failures
 
-      block #*died [ true =: ok? self resume ] opens
+      block #__died__ [ true =: ok? self resume ] opens
       block do
 
       ok? not => [

--- a/env/repl/repl.nk
+++ b/env/repl/repl.nk
@@ -131,7 +131,7 @@ _pgRoot #? [
          will report the error when it happens."
         reportError true =: error
         self resume
-      ] @: *died
+      ] @: __died__
 
       [ pgStackCopy pgRootInstance line slurp hydrate! ] measure =: durationMs
     ] do

--- a/examples/hello.nk
+++ b/examples/hello.nk
@@ -45,7 +45,7 @@ consProduct echo
   [
     [ ] x toQuote <<  ' @ ' << y toQuote <<
     [ stitch ] '' reduce
-  ] @: *asQuote
+  ] @: __asQuote__
 
   this
 ] @: point
@@ -70,7 +70,7 @@ consProduct echo
 
 block new orphan reparent [
   "Extend with a word trap that does nothing."
-  [ ] @: *trap
+  [ ] @: __trap__
 ] extend
 
 vals echo "should be: [ x y + Algebraic stuff test huh? ]"

--- a/examples/hello.nk
+++ b/examples/hello.nk
@@ -45,7 +45,7 @@ consProduct echo
   [
     [ ] x toQuote <<  ' @ ' << y toQuote <<
     [ stitch ] '' reduce
-  ] @: __asQuote__
+  ] @: __quote__
 
   this
 ] @: point

--- a/examples/html.nk
+++ b/examples/html.nk
@@ -38,7 +38,7 @@
   "This word trap will catch literally all words opened in innerHTML,
    because htmlContext is an orphan. It isn't related in any way to
    innerHTML right now, but it will be just a moment later."
-  htmlContext #*trap [
+  htmlContext #__trap__ [
     """( <> B | <>: Q -- ): creates a tag with Block content.
      Block may contain other such tags, or attributes | Attaches
      an attribute with Quote value onto the wrapping tag.

--- a/examples/lch-prompt.nk
+++ b/examples/lch-prompt.nk
@@ -29,7 +29,7 @@ console:truecolor
 
   "When someone wants to use `buffer` in place of a quote,
    give them up-to-date `content`."
-  [ content ] @: __asQuote__
+  [ content ] @: __quote__
 
   [ "( I -- ): deletes grapheme at Index in this buffer."
     content empty? => [ drop ^ ]
@@ -61,7 +61,7 @@ console:truecolor
 
   "When someone wants to use `cursor` in place of a decimal,
    give them up-to-date `pos`."
-  [ pos ] @: __asDecimal__
+  [ pos ] @: __decimal__
 
   "-*-*-*-*- Movement etc. -*-*-*-*-"
 

--- a/examples/lch-prompt.nk
+++ b/examples/lch-prompt.nk
@@ -29,7 +29,7 @@ console:truecolor
 
   "When someone wants to use `buffer` in place of a quote,
    give them up-to-date `content`."
-  [ content ] @: *asQuote
+  [ content ] @: __asQuote__
 
   [ "( I -- ): deletes grapheme at Index in this buffer."
     content empty? => [ drop ^ ]
@@ -61,7 +61,7 @@ console:truecolor
 
   "When someone wants to use `cursor` in place of a decimal,
    give them up-to-date `pos`."
-  [ pos ] @: *asDecimal
+  [ pos ] @: __asDecimal__
 
   "-*-*-*-*- Movement etc. -*-*-*-*-"
 
@@ -348,7 +348,7 @@ true $: running?
    over the place."
   finalize
   die
-] @: *died
+] @: __died__
 
 
 BG withEchoBg

--- a/examples/mathrepl.nk
+++ b/examples/mathrepl.nk
@@ -196,7 +196,7 @@ orphan $: operators
   false $: isAnswerRunnable?
 
   [ "( Q -- ): sets answer equal to Quote."
-    [ false =: isAnswerRunnable? ] @: *died
+    [ false =: isAnswerRunnable? ] @: __died__
 
     dup =: answer
 
@@ -214,7 +214,7 @@ orphan $: operators
     [ "If we fail for some reason, set the isAnswerRunnable flag
        and leave last valid result."
       drop  false =: isAnswerRunnable?  _lastOkResult
-    ] @: *died
+    ] @: __died__
 
     isAnswerRunnable? => [
       "If result block is empty, go back to 0 as the last result."
@@ -373,7 +373,7 @@ orphan $: operators
   ] @: finalize
 
 
-  [ finalize die ] @: *died
+  [ finalize die ] @: __died__
 
   console:on
   console:truecolor

--- a/examples/sdl.nk
+++ b/examples/sdl.nk
@@ -134,7 +134,7 @@
   [ [ SDL_Quit sdl:quit ] -- nothing ]
 ] _sdl
 
-[ sdl:quit die ] @: *died
+[ sdl:quit die ] @: __died__
 
 [ 0 < => [ sdl:error die ] ] @: sdl:ensure
 

--- a/examples/snake.new.nk
+++ b/examples/snake.new.nk
@@ -36,7 +36,7 @@ needsCapability: console
     0 randTo: [ console:height 1 - ] =: y
   ] @: moveToRandomPosition
 
-  [ [ x '@' y ] ~* ] @: *asQuote
+  [ [ x '@' y ] ~* ] @: __asQuote__
 
   this
 ] @: console:point
@@ -104,7 +104,7 @@ needsCapability: console
 
   "Die gracefully in case an error occurs. Otherwise, the terminal
    will be messed up and most of the error will be omitted."
-  [ console:off die ] @: *died
+  [ console:off die ] @: __died__
 
   console:on
     0 console:setTimeout "Do not wait for input."

--- a/examples/snake.new.nk
+++ b/examples/snake.new.nk
@@ -36,7 +36,7 @@ needsCapability: console
     0 randTo: [ console:height 1 - ] =: y
   ] @: moveToRandomPosition
 
-  [ [ x '@' y ] ~* ] @: __asQuote__
+  [ [ x '@' y ] ~* ] @: __quote__
 
   this
 ] @: console:point

--- a/examples/snake.nk
+++ b/examples/snake.nk
@@ -55,7 +55,7 @@ needsCapability: console
 
   [
     [ x '@' y ] ~*
-  ] @: *asQuote
+  ] @: __asQuote__
 
   this
 ] @: tvec2
@@ -171,7 +171,7 @@ needsCapability: console
 
   [ "Sets up death handlers, enables console API, and starts
      the main loop. After main loop ends/errs, disables console."
-    console:on [ console:off reportError ] @: *died
+    console:on [ console:off reportError ] @: __died__
 
     "Do not wait for input if there's none:"
     0 console:setTimeout

--- a/examples/snake.nk
+++ b/examples/snake.nk
@@ -55,7 +55,7 @@ needsCapability: console
 
   [
     [ x '@' y ] ~*
-  ] @: __asQuote__
+  ] @: __quote__
 
   this
 ] @: tvec2

--- a/src/novika/capabilities/impl/essential.cr
+++ b/src/novika/capabilities/impl/essential.cr
@@ -342,12 +342,12 @@ module Novika::Capabilities::Impl
 
       target.at("word?", <<-END
       ( F -- true/false ): leaves whether Form is a word form,
-       or a block that implements '*asWord'.
+       or a block that implements '__asWord__'.
 
       ```
       #foo word? leaves: true
 
-      [ #foo $: *asWord this ] open word? leaves: true
+      [ #foo $: __asWord__ this ] open word? leaves: true
       ```
       END
       ) do |_, stack|
@@ -409,12 +409,12 @@ module Novika::Capabilities::Impl
       #foo asWord leaves: [ foo ]
       ```
 
-      `*asWord` hook can make a block usable in place of a word,
+      `__asWord__` hook can make a block usable in place of a word,
       provided its definition leaves a word or a block which
-      implements '*asWord':
+      implements '__asWord__':
 
       ```
-      [ $: x x $: *asWord this ] @: a
+      [ $: x x $: __asWord__ this ] @: a
       #foo a asWord "beware: leaves instance of a"
       #boo a a asWord "beware: leaves instance of a"
       ```
@@ -423,11 +423,11 @@ module Novika::Capabilities::Impl
 
       target.at("quotedWord?", <<-END
       ( F -- true/false ): leaves whether Form is a quoted word
-       form, or a block that implements '*asQuotedWord'.
+       form, or a block that implements '__asQuotedWord__'.
 
       ```
       ##foo quotedWord? leaves: true
-      [ ##foo $: *asQuotedWord this ] open quotedWord? leaves: true
+      [ ##foo $: __asQuotedWord__ this ] open quotedWord? leaves: true
       ```
       END
       ) do |_, stack|
@@ -451,12 +451,12 @@ module Novika::Capabilities::Impl
       ##foo asQuotedWord leaves: #foo
       ```
 
-      `*asQuotedWord` hook can make a block usable in place of
+      `__asQuotedWord__` hook can make a block usable in place of
       a quoted word, provided its definition leaves a quoted
-      word or a block that implements `*asQuotedWord`:
+      word or a block that implements `__asQuotedWord__`:
 
       ```
-      [ $: x x $: *asQuotedWord this ] @: a
+      [ $: x x $: __asQuotedWord__ this ] @: a
       ##foo a asQuotedWord "beware: leaves instance of a"
       ##boo a a asQuotedWord "beware: leaves instance of a"
       ```
@@ -465,11 +465,11 @@ module Novika::Capabilities::Impl
 
       target.at("decimal?", <<-END
       ( F -- true/false ): leaves whether Form is a decimal form,
-       or a block that implements '*asDecimal'.
+       or a block that implements '__asDecimal__'.
 
       ```
       123 decimal? leaves: true
-      [ 123 $: *asDecimal this ] open decimal? leaves: true
+      [ 123 $: __asDecimal__ this ] open decimal? leaves: true
       ```
       END
       ) do |_, stack|
@@ -493,12 +493,12 @@ module Novika::Capabilities::Impl
       100 asDecimal leaves: 100
       ```
 
-      `*asDecimal` hook can make a block usable in place of a
+      `__asDecimal__` hook can make a block usable in place of a
       decimal, provided its definition leaves a decimal or a
-      block that implements `*asDecimal`:
+      block that implements `__asDecimal__`:
 
       ```
-      [ $: x x $: *asDecimal this ] @: a
+      [ $: x x $: __asDecimal__ this ] @: a
       100 a asDecimal "beware: leaves an instance of a"
       200 a a asDecimal "beware: leaves an instance of a"
       ```
@@ -507,11 +507,11 @@ module Novika::Capabilities::Impl
 
       target.at("quote?", <<-END
       ( F -- true/false ): leaves whether Form is a quote form,
-       or a block that implements '*asQuote'.
+       or a block that implements '__asQuote__'.
 
       ```
       'foo' quote? leaves: true
-      [ 'foo' $: *asQuote this ] open quote? leaves: true
+      [ 'foo' $: __asQuote__ this ] open quote? leaves: true
       ```
       END
       ) do |_, stack|
@@ -535,12 +535,12 @@ module Novika::Capabilities::Impl
       'foo' asQuote leaves: 'foo'
       ```
 
-      `*asQuote` hook can make a block usable in place of a
+      `__asQuote__` hook can make a block usable in place of a
       quote, provided its definition leaves a quote or a block
-      that implements `*asQuote`:
+      that implements `__asQuote__`:
 
       ```
-      [ $: x x $: *asQuote this ] @: a
+      [ $: x x $: __asQuote__ this ] @: a
       'foo' a asQuote "beware: leaves instance of a"
       'boo' a a asQuote "beware: leaves instance of a"
       ```
@@ -549,11 +549,11 @@ module Novika::Capabilities::Impl
 
       target.at("boolean?", <<-END
       ( F -- true/false ): leaves whether Form is a boolean form,
-       or a block that implements '*asBoolean'.
+       or a block that implements '__asBoolean__'.
 
       ```
       true boolean? leaves: true
-      [ true $: *asBoolean this ] open boolean? leaves: true
+      [ true $: __asBoolean__ this ] open boolean? leaves: true
       ```
       END
       ) do |_, stack|
@@ -578,12 +578,12 @@ module Novika::Capabilities::Impl
       false asBoolean leaves: false
       ```
 
-      `*asBoolean` hook can make a block usable in place of a
+      `__asBoolean__` hook can make a block usable in place of a
       boolean, provided its definition leaves a boolean or a
-      block that implements `*asBoolean`:
+      block that implements `__asBoolean__`:
 
       ```
-      [ $: x x $: *asBoolean this ] @: a
+      [ $: x x $: __asBoolean__ this ] @: a
       true a asBoolean "beware: leaves an instance of a"
       true a a asBoolean "beware: leaves an instance of a"
       ```
@@ -613,11 +613,11 @@ module Novika::Capabilities::Impl
 
       target.at("color?", <<-END
       ( F -- true/false ): leaves whether Form is a color form,
-       or a block that implements '*asColor'.
+       or a block that implements '__asColor__'.
 
       ```
       0 0 0 rgb color? leaves: true
-      [ 0 0 0 rgb $: *asColor this ] open color? leaves: true
+      [ 0 0 0 rgb $: __asColor__ this ] open color? leaves: true
       ```
       END
       ) do |_, stack|
@@ -641,12 +641,12 @@ module Novika::Capabilities::Impl
       0 0 0 rgb asColor toQuote leaves: 'rgb(0, 0, 0)'
       ```
 
-      `*asColor` hook can make a block usable in place of a
+      `__asColor__` hook can make a block usable in place of a
       color, provided its definition leaves a color or a block
-      that implements `*asColor`:
+      that implements `__asColor__`:
 
       ```
-      [ $: x x $: *asColor this ] @: a
+      [ $: x x $: __asColor__ this ] @: a
       0 0 0 rgb a asColor "beware: leaves an instance of a"
       0 0 0 rgb a a asColor "beware: leaves an instance of a"
       ```
@@ -655,11 +655,11 @@ module Novika::Capabilities::Impl
 
       target.at("byteslice?", <<-END
       ( F -- true/false ): leaves whether Form is a byteslice
-       form, or a block that implements '*asByteslice'.
+       form, or a block that implements '__asByteslice__'.
 
       ```
       'hello world' toByteslice byteslice? leaves: true
-      [ [ 'Hi!' toByteslice ] $: *asByteslice this ] open byteslice? leaves: true
+      [ [ 'Hi!' toByteslice ] $: __asByteslice__ this ] open byteslice? leaves: true
       ```
       END
       ) do |_, stack|
@@ -683,12 +683,12 @@ module Novika::Capabilities::Impl
       'hello world' toByteslice asByteslice leaves: '[byteslice, consists of 11 mutable byte(s)]'
       ```
 
-      `*asByteslice` hook can make a block usable in place of
+      `__asByteslice__` hook can make a block usable in place of
       a byteslice, provided its definition leaves a byteslice
-      or a block that implements `*asByteslice`:
+      or a block that implements `__asByteslice__`:
 
       ```
-      [ $: x x $: *asByteslice this ] @: a
+      [ $: x x $: __asByteslice__ this ] @: a
       'foo' toByteslice a asByteslice "beware: leaves an instance of a"
       'foo' toByteslice a a asByteslice "beware: leaves an instance of a"
       ```

--- a/src/novika/capabilities/impl/essential.cr
+++ b/src/novika/capabilities/impl/essential.cr
@@ -342,12 +342,12 @@ module Novika::Capabilities::Impl
 
       target.at("word?", <<-END
       ( F -- true/false ): leaves whether Form is a word form,
-       or a block that implements '__asWord__'.
+       or a block that implements '__word__'.
 
       ```
       #foo word? leaves: true
 
-      [ #foo $: __asWord__ this ] open word? leaves: true
+      [ #foo $: __word__ this ] open word? leaves: true
       ```
       END
       ) do |_, stack|
@@ -409,12 +409,12 @@ module Novika::Capabilities::Impl
       #foo asWord leaves: [ foo ]
       ```
 
-      `__asWord__` hook can make a block usable in place of a word,
+      `__word__` hook can make a block usable in place of a word,
       provided its definition leaves a word or a block which
-      implements '__asWord__':
+      implements '__word__':
 
       ```
-      [ $: x x $: __asWord__ this ] @: a
+      [ $: x x $: __word__ this ] @: a
       #foo a asWord "beware: leaves instance of a"
       #boo a a asWord "beware: leaves instance of a"
       ```
@@ -423,11 +423,11 @@ module Novika::Capabilities::Impl
 
       target.at("quotedWord?", <<-END
       ( F -- true/false ): leaves whether Form is a quoted word
-       form, or a block that implements '__asQuotedWord__'.
+       form, or a block that implements '__quotedword__'.
 
       ```
       ##foo quotedWord? leaves: true
-      [ ##foo $: __asQuotedWord__ this ] open quotedWord? leaves: true
+      [ ##foo $: __quotedword__ this ] open quotedWord? leaves: true
       ```
       END
       ) do |_, stack|
@@ -451,12 +451,12 @@ module Novika::Capabilities::Impl
       ##foo asQuotedWord leaves: #foo
       ```
 
-      `__asQuotedWord__` hook can make a block usable in place of
+      `__quotedword__` hook can make a block usable in place of
       a quoted word, provided its definition leaves a quoted
-      word or a block that implements `__asQuotedWord__`:
+      word or a block that implements `__quotedword__`:
 
       ```
-      [ $: x x $: __asQuotedWord__ this ] @: a
+      [ $: x x $: __quotedword__ this ] @: a
       ##foo a asQuotedWord "beware: leaves instance of a"
       ##boo a a asQuotedWord "beware: leaves instance of a"
       ```
@@ -465,11 +465,11 @@ module Novika::Capabilities::Impl
 
       target.at("decimal?", <<-END
       ( F -- true/false ): leaves whether Form is a decimal form,
-       or a block that implements '__asDecimal__'.
+       or a block that implements '__decimal__'.
 
       ```
       123 decimal? leaves: true
-      [ 123 $: __asDecimal__ this ] open decimal? leaves: true
+      [ 123 $: __decimal__ this ] open decimal? leaves: true
       ```
       END
       ) do |_, stack|
@@ -493,12 +493,12 @@ module Novika::Capabilities::Impl
       100 asDecimal leaves: 100
       ```
 
-      `__asDecimal__` hook can make a block usable in place of a
+      `__decimal__` hook can make a block usable in place of a
       decimal, provided its definition leaves a decimal or a
-      block that implements `__asDecimal__`:
+      block that implements `__decimal__`:
 
       ```
-      [ $: x x $: __asDecimal__ this ] @: a
+      [ $: x x $: __decimal__ this ] @: a
       100 a asDecimal "beware: leaves an instance of a"
       200 a a asDecimal "beware: leaves an instance of a"
       ```
@@ -507,11 +507,11 @@ module Novika::Capabilities::Impl
 
       target.at("quote?", <<-END
       ( F -- true/false ): leaves whether Form is a quote form,
-       or a block that implements '__asQuote__'.
+       or a block that implements '__quote__'.
 
       ```
       'foo' quote? leaves: true
-      [ 'foo' $: __asQuote__ this ] open quote? leaves: true
+      [ 'foo' $: __quote__ this ] open quote? leaves: true
       ```
       END
       ) do |_, stack|
@@ -535,12 +535,12 @@ module Novika::Capabilities::Impl
       'foo' asQuote leaves: 'foo'
       ```
 
-      `__asQuote__` hook can make a block usable in place of a
+      `__quote__` hook can make a block usable in place of a
       quote, provided its definition leaves a quote or a block
-      that implements `__asQuote__`:
+      that implements `__quote__`:
 
       ```
-      [ $: x x $: __asQuote__ this ] @: a
+      [ $: x x $: __quote__ this ] @: a
       'foo' a asQuote "beware: leaves instance of a"
       'boo' a a asQuote "beware: leaves instance of a"
       ```
@@ -549,11 +549,11 @@ module Novika::Capabilities::Impl
 
       target.at("boolean?", <<-END
       ( F -- true/false ): leaves whether Form is a boolean form,
-       or a block that implements '__asBoolean__'.
+       or a block that implements '__boolean__'.
 
       ```
       true boolean? leaves: true
-      [ true $: __asBoolean__ this ] open boolean? leaves: true
+      [ true $: __boolean__ this ] open boolean? leaves: true
       ```
       END
       ) do |_, stack|
@@ -578,12 +578,12 @@ module Novika::Capabilities::Impl
       false asBoolean leaves: false
       ```
 
-      `__asBoolean__` hook can make a block usable in place of a
+      `__boolean__` hook can make a block usable in place of a
       boolean, provided its definition leaves a boolean or a
-      block that implements `__asBoolean__`:
+      block that implements `__boolean__`:
 
       ```
-      [ $: x x $: __asBoolean__ this ] @: a
+      [ $: x x $: __boolean__ this ] @: a
       true a asBoolean "beware: leaves an instance of a"
       true a a asBoolean "beware: leaves an instance of a"
       ```
@@ -613,11 +613,11 @@ module Novika::Capabilities::Impl
 
       target.at("color?", <<-END
       ( F -- true/false ): leaves whether Form is a color form,
-       or a block that implements '__asColor__'.
+       or a block that implements '__color__'.
 
       ```
       0 0 0 rgb color? leaves: true
-      [ 0 0 0 rgb $: __asColor__ this ] open color? leaves: true
+      [ 0 0 0 rgb $: __color__ this ] open color? leaves: true
       ```
       END
       ) do |_, stack|
@@ -641,12 +641,12 @@ module Novika::Capabilities::Impl
       0 0 0 rgb asColor toQuote leaves: 'rgb(0, 0, 0)'
       ```
 
-      `__asColor__` hook can make a block usable in place of a
+      `__color__` hook can make a block usable in place of a
       color, provided its definition leaves a color or a block
-      that implements `__asColor__`:
+      that implements `__color__`:
 
       ```
-      [ $: x x $: __asColor__ this ] @: a
+      [ $: x x $: __color__ this ] @: a
       0 0 0 rgb a asColor "beware: leaves an instance of a"
       0 0 0 rgb a a asColor "beware: leaves an instance of a"
       ```
@@ -655,11 +655,11 @@ module Novika::Capabilities::Impl
 
       target.at("byteslice?", <<-END
       ( F -- true/false ): leaves whether Form is a byteslice
-       form, or a block that implements '__asByteslice__'.
+       form, or a block that implements '__byteslice__'.
 
       ```
       'hello world' toByteslice byteslice? leaves: true
-      [ [ 'Hi!' toByteslice ] $: __asByteslice__ this ] open byteslice? leaves: true
+      [ [ 'Hi!' toByteslice ] $: __byteslice__ this ] open byteslice? leaves: true
       ```
       END
       ) do |_, stack|
@@ -683,12 +683,12 @@ module Novika::Capabilities::Impl
       'hello world' toByteslice asByteslice leaves: '[byteslice, consists of 11 mutable byte(s)]'
       ```
 
-      `__asByteslice__` hook can make a block usable in place of
+      `__byteslice__` hook can make a block usable in place of
       a byteslice, provided its definition leaves a byteslice
-      or a block that implements `__asByteslice__`:
+      or a block that implements `__byteslice__`:
 
       ```
-      [ $: x x $: __asByteslice__ this ] @: a
+      [ $: x x $: __byteslice__ this ] @: a
       'foo' toByteslice a asByteslice "beware: leaves an instance of a"
       'foo' toByteslice a a asByteslice "beware: leaves an instance of a"
       ```

--- a/src/novika/capabilities/system.cr
+++ b/src/novika/capabilities/system.cr
@@ -80,7 +80,7 @@ module Novika::Capabilities
        stream, given an Error object.
 
       You can obtain an error object by, e.g., catching it
-      in `*died`.
+      in `__died__`.
       END
       ) do |engine, stack|
         error = stack.drop.a(Error)

--- a/src/novika/engine.cr
+++ b/src/novika/engine.cr
@@ -92,7 +92,7 @@ module Novika
     # Pushes *engine* onto the engine stack.
     def self.push(engine : Engine) : Engine
       unless @@stack.size.in?(0..MAX_ENGINES)
-        raise Error.new("bad engine stack depth: maybe deep recursion in *as...?")
+        raise Error.new("bad engine stack depth: maybe deep recursion in __as...__?")
       end
 
       @@stack << engine

--- a/src/novika/engine.cr
+++ b/src/novika/engine.cr
@@ -92,7 +92,7 @@ module Novika
     # Pushes *engine* onto the engine stack.
     def self.push(engine : Engine) : Engine
       unless @@stack.size.in?(0..MAX_ENGINES)
-        raise Error.new("bad engine stack depth: maybe deep recursion in __as...__?")
+        raise Error.new("bad engine stack depth: deep recursion in a __metaword__?")
       end
 
       @@stack << engine

--- a/src/novika/forms/block.cr
+++ b/src/novika/forms/block.cr
@@ -32,33 +32,33 @@ module Novika
     MAX_NESTED_COUNT_TO_S = 12
 
     # Block to word hook name.
-    AS_WORD = Word.new("*asWord")
+    AS_WORD = Word.new("__asWord__")
 
     # Block to color hook name.
-    AS_COLOR = Word.new("*asColor")
+    AS_COLOR = Word.new("__asColor__")
 
     # Block to quote hook name.
-    AS_QUOTE = Word.new("*asQuote")
+    AS_QUOTE = Word.new("__asQuote__")
 
     # Block to decimal hook name.
-    AS_DECIMAL = Word.new("*asDecimal")
+    AS_DECIMAL = Word.new("__asDecimal__")
 
     # Block to boolean hook name.
-    AS_BOOLEAN = Word.new("*asBoolean")
+    AS_BOOLEAN = Word.new("__asBoolean__")
 
     # Block to quoted word hook name.
-    AS_QUOTED_WORD = Word.new("*asQuotedWord")
+    AS_QUOTED_WORD = Word.new("__asQuotedWord__")
 
     # Block to byteslice hook name.
-    AS_BYTESLICE = Word.new("*asByteslice")
+    AS_BYTESLICE = Word.new("__asByteslice__")
 
     # On shove hook name.
-    META_ON_SHOVE = Word.new("*-shove")
+    META_ON_SHOVE = Word.new("__shove__")
 
     # On cherry hook name. Cherry is like drop but it returns/
     # leaves the form dropped, plus works on a particular block
     # rather than on the stack.
-    META_ON_CHERRY = Word.new("*-cherry")
+    META_ON_CHERRY = Word.new("__cherry__")
 
     # Whether this block is a leaf. A block is a leaf when
     # it has no blocks in its tape.
@@ -739,7 +739,7 @@ module Novika
         # but we need to track cast depth.
         #
         # Give up when exceeded the max engine count.
-        die("bad engine depth: maybe deep recursion in *as...?")
+        die("bad engine depth: maybe deep recursion in __as...__?")
       end
 
       entry = flat_at?(name) || return

--- a/src/novika/forms/block.cr
+++ b/src/novika/forms/block.cr
@@ -32,25 +32,25 @@ module Novika
     MAX_NESTED_COUNT_TO_S = 12
 
     # Block to word hook name.
-    AS_WORD = Word.new("__asWord__")
+    AS_WORD = Word.new("__word__")
 
     # Block to color hook name.
-    AS_COLOR = Word.new("__asColor__")
+    AS_COLOR = Word.new("__color__")
 
     # Block to quote hook name.
-    AS_QUOTE = Word.new("__asQuote__")
+    AS_QUOTE = Word.new("__quote__")
 
     # Block to decimal hook name.
-    AS_DECIMAL = Word.new("__asDecimal__")
+    AS_DECIMAL = Word.new("__decimal__")
 
     # Block to boolean hook name.
-    AS_BOOLEAN = Word.new("__asBoolean__")
+    AS_BOOLEAN = Word.new("__boolean__")
 
     # Block to quoted word hook name.
-    AS_QUOTED_WORD = Word.new("__asQuotedWord__")
+    AS_QUOTED_WORD = Word.new("__quotedword__")
 
     # Block to byteslice hook name.
-    AS_BYTESLICE = Word.new("__asByteslice__")
+    AS_BYTESLICE = Word.new("__byteslice__")
 
     # On shove hook name.
     META_ON_SHOVE = Word.new("__shove__")
@@ -739,7 +739,7 @@ module Novika
         # but we need to track cast depth.
         #
         # Give up when exceeded the max engine count.
-        die("bad engine depth: maybe deep recursion in __as...__?")
+        die("bad engine depth: deep recursion in a __metaword__?")
       end
 
       entry = flat_at?(name) || return

--- a/src/novika/forms/words.cr
+++ b/src/novika/forms/words.cr
@@ -40,7 +40,7 @@ module Novika
 
       while block && (trap = block.entry_for?(TRAP))
         # A trap entry exists for this word in *block*. Traps are
-        # inherited as opposed to conversion words like __asDecimal__.
+        # inherited as opposed to conversion words like __decimal__.
         form = trap.form
 
         if form.is_a?(Block) && form.prototype.same?(current.prototype)

--- a/src/novika/forms/words.cr
+++ b/src/novika/forms/words.cr
@@ -5,10 +5,10 @@ module Novika
     include Form
 
     # Death hook name.
-    DIED = Word.new("*died")
+    DIED = Word.new("__died__")
 
     # Undefined word hook name.
-    TRAP = Word.new("*trap")
+    TRAP = Word.new("__trap__")
 
     # Returns the underlying string id.
     getter id : String
@@ -40,7 +40,7 @@ module Novika
 
       while block && (trap = block.entry_for?(TRAP))
         # A trap entry exists for this word in *block*. Traps are
-        # inherited as opposed to conversion words like *asDecimal.
+        # inherited as opposed to conversion words like __asDecimal__.
         form = trap.form
 
         if form.is_a?(Block) && form.prototype.same?(current.prototype)

--- a/tests/block.nk
+++ b/tests/block.nk
@@ -1297,9 +1297,9 @@ describe 'minmax' [
     [ 100 200 5 300 405 ] minmax stack shallowCopy [ 5 405 ] assert=
   ]
 
-  it should 'handle blocks which implement __asDecimal__' [
-    [ -101 $: __asDecimal__ this ] open $: a
-    [ 500 $: __asDecimal__ this ] open $: b
+  it should 'handle blocks which implement __decimal__' [
+    [ -101 $: __decimal__ this ] open $: a
+    [ 500 $: __decimal__ this ] open $: b
 
     "There is no good way to do this right now unfortunately..."
     [ -100 100 ] [ <| a |> b ] there
@@ -1343,8 +1343,8 @@ describe 'sum' [
     [ 100 200 300 ] sum 600 assert=
   ]
 
-  it should 'support blocks implementing __asDecimal__' [
-    [ $: n [ n 1 + ] @: __asDecimal__ this ] @: foos
+  it should 'support blocks implementing __decimal__' [
+    [ $: n [ n 1 + ] @: __decimal__ this ] @: foos
 
     100 foos "101"
     200 foos "201"
@@ -1373,8 +1373,8 @@ describe 'product' [
     [ 5 4 3 2 ] product 120 assert=
   ]
 
-  it should 'support blocks implementing __asDecimal__' [
-    [ $: n [ n 1 + ] @: __asDecimal__ this ] @: foos
+  it should 'support blocks implementing __decimal__' [
+    [ $: n [ n 1 + ] @: __decimal__ this ] @: foos
 
     100 foos "101"
     200 foos "201"
@@ -1409,8 +1409,8 @@ describe 'minmaxBy' [
     stack shallowCopy [ 'A' 'BAAAAAAB' ] assert=
   ]
 
-  it should 'support blocks implementing __asDecimal__ as Transform results' [
-    [ $: s [ s count ] @: __asDecimal__ this ] @: toAwesomeBlock
+  it should 'support blocks implementing __decimal__ as Transform results' [
+    [ $: s [ s count ] @: __decimal__ this ] @: toAwesomeBlock
 
     [ 'AA' 'A' 'AAAB' 'foo' 'barbeee' ] [ toAwesomeBlock ] minmaxBy
 
@@ -1445,7 +1445,7 @@ describe 'maxBy' [
 describe 'sumBy' [
   in lang
 
-  [ $: s [ s count ] @: __asDecimal__ this ] @: toAwesomeBlock
+  [ $: s [ s count ] @: __decimal__ this ] @: toAwesomeBlock
 
   it should 'leave zero when list block is empty' [
     [ ] [ ] sumBy 0 assert=
@@ -1480,7 +1480,7 @@ describe 'sumBy' [
     ] assert=
   ]
 
-  it should 'support blocks implementing __asDecimal__ as results/summands' [
+  it should 'support blocks implementing __decimal__ as results/summands' [
     'foobee' toAwesomeBlock $: myBestBlock
 
     [ 'foo' 3 myBestBlock 4 'bar' 5 ] here [ dup quote? => [ toAwesomeBlock ] ] sumBy
@@ -1501,7 +1501,7 @@ describe 'sumBy' [
 describe 'productBy' [
   in lang
 
-  [ $: s [ s count ] @: __asDecimal__ this ] @: toAwesomeBlock
+  [ $: s [ s count ] @: __decimal__ this ] @: toAwesomeBlock
 
   it should 'leave 1 when list block is empty' [
     [ ] [ ] productBy 1 assert=
@@ -1536,7 +1536,7 @@ describe 'productBy' [
     ] assert=
   ]
 
-  it should 'support blocks implementing __asDecimal__ as results/multiplicands' [
+  it should 'support blocks implementing __decimal__ as results/multiplicands' [
     'foobee' toAwesomeBlock $: myBestBlock
 
     [ 'foo' 3 myBestBlock 4 'bar' 5 ] here [ dup quote? => [ toAwesomeBlock ] ] productBy

--- a/tests/block.nk
+++ b/tests/block.nk
@@ -1273,7 +1273,7 @@ describe 'conjure/here' [
   ]
 
   it should 'trigger word trap when word is undefined' [
-    [ toQuote 1 sliceQuoteAt nip ] @: *trap
+    [ toQuote 1 sliceQuoteAt nip ] @: __trap__
     foobar here 'oobar' assert=
   ]
 ]
@@ -1297,9 +1297,9 @@ describe 'minmax' [
     [ 100 200 5 300 405 ] minmax stack shallowCopy [ 5 405 ] assert=
   ]
 
-  it should 'handle blocks which implement *asDecimal' [
-    [ -101 $: *asDecimal this ] open $: a
-    [ 500 $: *asDecimal this ] open $: b
+  it should 'handle blocks which implement __asDecimal__' [
+    [ -101 $: __asDecimal__ this ] open $: a
+    [ 500 $: __asDecimal__ this ] open $: b
 
     "There is no good way to do this right now unfortunately..."
     [ -100 100 ] [ <| a |> b ] there
@@ -1343,8 +1343,8 @@ describe 'sum' [
     [ 100 200 300 ] sum 600 assert=
   ]
 
-  it should 'support blocks implementing *asDecimal' [
-    [ $: n [ n 1 + ] @: *asDecimal this ] @: foos
+  it should 'support blocks implementing __asDecimal__' [
+    [ $: n [ n 1 + ] @: __asDecimal__ this ] @: foos
 
     100 foos "101"
     200 foos "201"
@@ -1373,8 +1373,8 @@ describe 'product' [
     [ 5 4 3 2 ] product 120 assert=
   ]
 
-  it should 'support blocks implementing *asDecimal' [
-    [ $: n [ n 1 + ] @: *asDecimal this ] @: foos
+  it should 'support blocks implementing __asDecimal__' [
+    [ $: n [ n 1 + ] @: __asDecimal__ this ] @: foos
 
     100 foos "101"
     200 foos "201"
@@ -1409,8 +1409,8 @@ describe 'minmaxBy' [
     stack shallowCopy [ 'A' 'BAAAAAAB' ] assert=
   ]
 
-  it should 'support blocks implementing *asDecimal as Transform results' [
-    [ $: s [ s count ] @: *asDecimal this ] @: toAwesomeBlock
+  it should 'support blocks implementing __asDecimal__ as Transform results' [
+    [ $: s [ s count ] @: __asDecimal__ this ] @: toAwesomeBlock
 
     [ 'AA' 'A' 'AAAB' 'foo' 'barbeee' ] [ toAwesomeBlock ] minmaxBy
 
@@ -1445,7 +1445,7 @@ describe 'maxBy' [
 describe 'sumBy' [
   in lang
 
-  [ $: s [ s count ] @: *asDecimal this ] @: toAwesomeBlock
+  [ $: s [ s count ] @: __asDecimal__ this ] @: toAwesomeBlock
 
   it should 'leave zero when list block is empty' [
     [ ] [ ] sumBy 0 assert=
@@ -1480,7 +1480,7 @@ describe 'sumBy' [
     ] assert=
   ]
 
-  it should 'support blocks implementing *asDecimal as results/summands' [
+  it should 'support blocks implementing __asDecimal__ as results/summands' [
     'foobee' toAwesomeBlock $: myBestBlock
 
     [ 'foo' 3 myBestBlock 4 'bar' 5 ] here [ dup quote? => [ toAwesomeBlock ] ] sumBy
@@ -1501,7 +1501,7 @@ describe 'sumBy' [
 describe 'productBy' [
   in lang
 
-  [ $: s [ s count ] @: *asDecimal this ] @: toAwesomeBlock
+  [ $: s [ s count ] @: __asDecimal__ this ] @: toAwesomeBlock
 
   it should 'leave 1 when list block is empty' [
     [ ] [ ] productBy 1 assert=
@@ -1536,7 +1536,7 @@ describe 'productBy' [
     ] assert=
   ]
 
-  it should 'support blocks implementing *asDecimal as results/multiplicands' [
+  it should 'support blocks implementing __asDecimal__ as results/multiplicands' [
     'foobee' toAwesomeBlock $: myBestBlock
 
     [ 'foo' 3 myBestBlock 4 'bar' 5 ] here [ dup quote? => [ toAwesomeBlock ] ] productBy

--- a/tests/bugs.nk
+++ b/tests/bugs.nk
@@ -41,23 +41,23 @@ describe 'Conversion words should not be inherited #25' [
   [
     [ ] $: x
 
-    'hello' $: *asQuote
-    [ 100 1 + ] @: *asDecimal
-    false $: *asBoolean
-    [ ##fubar ] @: *asQuotedWord
-    [ [ #baz $: *asWord this ] open ] @: *asWord
+    'hello' $: __asQuote__
+    [ 100 1 + ] @: __asDecimal__
+    false $: __asBoolean__
+    [ ##fubar ] @: __asQuotedWord__
+    [ [ #baz $: __asWord__ this ] open ] @: __asWord__
 
     this
   ] @: b
 
-  it dies 'because child doesn\'t inherit *asQuote' [ b.x asQuote ]
-  it dies 'because child doesn\'t inherit *asDecimal' [ b.x asDecimal ]
-  it dies 'because child doesn\'t inherit *asBoolean' [ b.x asBoolean ]
-  it dies 'because child doesn\'t inherit *asQuotedWord' [ b.x asQuotedWord ]
-  it dies 'because child doesn\'t inherit *asWord' [ b.x asWord ]
+  it dies 'because child doesn\'t inherit __asQuote__' [ b.x asQuote ]
+  it dies 'because child doesn\'t inherit __asDecimal__' [ b.x asDecimal ]
+  it dies 'because child doesn\'t inherit __asBoolean__' [ b.x asBoolean ]
+  it dies 'because child doesn\'t inherit __asQuotedWord__' [ b.x asQuotedWord ]
+  it dies 'because child doesn\'t inherit __asWord__' [ b.x asWord ]
 
-  [ [ ] $: x 'hello' $: *asQuote this ] @: issueEg1
-  [ [ ] $: x [ 100 1 + ] @: *asDecimal this ] @: issueEg2
+  [ [ ] $: x 'hello' $: __asQuote__ this ] @: issueEg1
+  [ [ ] $: x [ 100 1 + ] @: __asDecimal__ this ] @: issueEg2
 
   it should 'pass issue example #1' [ issueEg1 dup asQuote assert= ]
   it dies 'as expected in issue example #1' [ issueEg1.x asQuote ]
@@ -71,16 +71,16 @@ describe 'Infinite recursion when word undefined inside word trap #8' [
   in lang
 
   it dies 'because definition for this-word-is-undefined not found in the enclosing block(s)' [
-    [ this-word-is-undefined ] @: *trap
+    [ this-word-is-undefined ] @: __trap__
     this-word-is-undefined-and-will-trigger-the-trap
   ]
 
   it should 'climb traps' [
-    [ 100 ] @: *trap
+    [ 100 ] @: __trap__
     [
-      [ 200 trigger-upper-trap2 ] @: *trap
+      [ 200 trigger-upper-trap2 ] @: __trap__
       [
-        [ 300 trigger-upper-trap ] @: *trap
+        [ 300 trigger-upper-trap ] @: __trap__
         trigger-my-own-trap
       ] open
     ] vals [ trigger-my-own-trap 300 trigger-upper-trap 200 trigger-upper-trap2 100 ] assert=
@@ -145,7 +145,7 @@ describe 'Correct precedence with assertDies #52' [
 ]
 
 
-describe 'Death nesting, handle death inside *died handler #58' [
+describe 'Death nesting, handle death inside __died__ handler #58' [
   in lang
 
 
@@ -154,7 +154,7 @@ describe 'Death nesting, handle death inside *died handler #58' [
     false $: died?
 
     [
-      [ true =: died? ] @: *died
+      [ true =: died? ] @: __died__
       ">>>" swap "<<< ERROR"
 
       true =: gotPastError?
@@ -172,13 +172,13 @@ describe 'Death nesting, handle death inside *died handler #58' [
       [ nesting 1 + =: nesting ] $: nesting++
       [ afterError 1 + =: afterError ] @: afterError++
 
-      nesting++ @: *died
+      nesting++ @: __died__
 
       [
-        nesting++ @: *died
+        nesting++ @: __died__
 
         [
-          nesting++ @: *died
+          nesting++ @: __died__
 
           swap
           afterError++
@@ -200,15 +200,15 @@ describe 'Death nesting, handle death inside *died handler #58' [
     [ ] $: details
 
     [
-      [ getErrorDetails details gulp 'PERIOD' details gulp ] @: *died
+      [ getErrorDetails details gulp 'PERIOD' details gulp ] @: __died__
 
       [
-        [ getErrorDetails details gulp 'Boomba! 4th' die ] @: *died
+        [ getErrorDetails details gulp 'Boomba! 4th' die ] @: __died__
         [
-          [ getErrorDetails details gulp 'Kaboom! 3rd' die ] @: *died
+          [ getErrorDetails details gulp 'Kaboom! 3rd' die ] @: __died__
 
           [
-            [ getErrorDetails details gulp 'Bang! 2nd' die ] @: *died
+            [ getErrorDetails details gulp 'Bang! 2nd' die ] @: __died__
 
             'Boom! 1st' die
           ] do
@@ -225,16 +225,16 @@ describe 'Death nesting, handle death inside *died handler #58' [
     #nil $: error
     0 $: nesting
 
-    [ =: error nesting 1 + =: nesting ] @: *died
+    [ =: error nesting 1 + =: nesting ] @: __died__
 
     [
-      #die here @: *died
+      #die here @: __died__
 
       [
-        [ nesting 1 + =: nesting die ] @: *died
+        [ nesting 1 + =: nesting die ] @: __died__
 
         [
-          [ die "]] make sure that this is unreachable:" nesting 1 + =: nesting ] @: *died
+          [ die "]] make sure that this is unreachable:" nesting 1 + =: nesting ] @: __died__
 
           _probe enclose [ open ] hydrate
         ] do
@@ -256,7 +256,7 @@ describe 'Death nesting, handle death inside *died handler #58' [
       ] obj shallowCopy toOrphan "TODO: make toOrphan immutable?" $: _env
 
       [
-        [ getErrorDetails ] @: *died
+        [ getErrorDetails ] @: __died__
 
         new _env reparent vals
 
@@ -284,7 +284,7 @@ describe 'Death nesting, handle death inside *died handler #58' [
         100 $: foo
         200 $: bar
         [ foo bar + ] @: baz
-        [ getErrorDetails ] @: *died
+        [ getErrorDetails ] @: __died__
       ] obj shallowCopy toOrphan "TODO: make toOrphan immutable?" $: _env
 
       new _env reparent vals
@@ -301,13 +301,13 @@ describe 'Death nesting, handle death inside *died handler #58' [
     didGetPastVals true assert=
   ]
 
-  it should 'support nested *died' [
+  it should 'support nested __died__' [
     [
       [
         [ getErrorDetails
-          [ getErrorDetails ] @: *died
+          [ getErrorDetails ] @: __died__
           bar
-        ] @: *died
+        ] @: __died__
 
         1 baz
       ] vals
@@ -315,6 +315,25 @@ describe 'Death nesting, handle death inside *died handler #58' [
   ]
 ]
 
+"
+describe 'Bug: unhandled nested death infinite loop #68 ' [
+  in lang
+
+  it should 'handle nested death rather than looping indefinitely' [
+    [ [ [ p die ] open ] @: __died__ foo ] '' assertDies
+    [
+      [ die ] @: __died__
+      [
+        [
+          [ causes-this-to-evaluate-and-die ] @: __died__
+          undefined-word--^
+        ] @: __died__
+        boo
+      ] do
+    ] '' assertDies
+  ]
+]
+"
 
 describe 'Block.with and friends properly instantiating' [
   in lang

--- a/tests/bugs.nk
+++ b/tests/bugs.nk
@@ -41,23 +41,23 @@ describe 'Conversion words should not be inherited #25' [
   [
     [ ] $: x
 
-    'hello' $: __asQuote__
-    [ 100 1 + ] @: __asDecimal__
-    false $: __asBoolean__
-    [ ##fubar ] @: __asQuotedWord__
-    [ [ #baz $: __asWord__ this ] open ] @: __asWord__
+    'hello' $: __quote__
+    [ 100 1 + ] @: __decimal__
+    false $: __boolean__
+    [ ##fubar ] @: __quotedword__
+    [ [ #baz $: __word__ this ] open ] @: __word__
 
     this
   ] @: b
 
-  it dies 'because child doesn\'t inherit __asQuote__' [ b.x asQuote ]
-  it dies 'because child doesn\'t inherit __asDecimal__' [ b.x asDecimal ]
-  it dies 'because child doesn\'t inherit __asBoolean__' [ b.x asBoolean ]
-  it dies 'because child doesn\'t inherit __asQuotedWord__' [ b.x asQuotedWord ]
-  it dies 'because child doesn\'t inherit __asWord__' [ b.x asWord ]
+  it dies 'because child doesn\'t inherit __quote__' [ b.x asQuote ]
+  it dies 'because child doesn\'t inherit __decimal__' [ b.x asDecimal ]
+  it dies 'because child doesn\'t inherit __boolean__' [ b.x asBoolean ]
+  it dies 'because child doesn\'t inherit __quotedword__' [ b.x asQuotedWord ]
+  it dies 'because child doesn\'t inherit __word__' [ b.x asWord ]
 
-  [ [ ] $: x 'hello' $: __asQuote__ this ] @: issueEg1
-  [ [ ] $: x [ 100 1 + ] @: __asDecimal__ this ] @: issueEg2
+  [ [ ] $: x 'hello' $: __quote__ this ] @: issueEg1
+  [ [ ] $: x [ 100 1 + ] @: __decimal__ this ] @: issueEg2
 
   it should 'pass issue example #1' [ issueEg1 dup asQuote assert= ]
   it dies 'as expected in issue example #1' [ issueEg1.x asQuote ]

--- a/tests/decimal.nk
+++ b/tests/decimal.nk
@@ -84,8 +84,8 @@ describe 'Math: inter-domain decimal math' [
     1 '2' +
   ]
 
-  it should 'try to convert type block arguments to decimals via __asDecimal__' [
-    [ $: __asDecimal__ this ] @: foos
+  it should 'try to convert type block arguments to decimals via __decimal__' [
+    [ $: __decimal__ this ] @: foos
     100 foos 200 foos + 300 assert=
   ]
 
@@ -156,42 +156,42 @@ describe 'Math: floating point (precise) math' [
   ]
 ]
 
-describe '__asDecimal__ hook for implicit conversion of blocks to decimals' [
+describe '__decimal__ hook for implicit conversion of blocks to decimals' [
   in lang
 
-  it dies 'when block does not implement __asDecimal__' [
+  it dies 'when block does not implement __decimal__' [
     1 [ ] +
   ]
 
-  it should 'support blocks which implement __asDecimal__ literally' [
-    [ $: __asDecimal__ this ] @: wrap
+  it should 'support blocks which implement __decimal__ literally' [
+    [ $: __decimal__ this ] @: wrap
     1 2 wrap + 3 assert=
   ]
 
-  it should 'support blocks which implement __asDecimal__ computationally' [
-    [ $: value [ value dup * ] @: __asDecimal__ this ] @: squareWrap
+  it should 'support blocks which implement __decimal__ computationally' [
+    [ $: value [ value dup * ] @: __decimal__ this ] @: squareWrap
     1 2 squareWrap + 5 assert=
   ]
 
-  it dies 'when block does not return a decimal in __asDecimal__' [
-    [ toQuote $: __asDecimal__ this ] @: wrap
+  it dies 'when block does not return a decimal in __decimal__' [
+    [ toQuote $: __decimal__ this ] @: wrap
     1 2 wrap +
   ]
 
-  it should 'support blocks whose __asDecimal__ leaves block which implements __asDecimal__' [
-    [ $: n [ n ] @: __asDecimal__ this ] @: foos
-    [ $: __asDecimal__ this ] @: wrap
+  it should 'support blocks whose __decimal__ leaves block which implements __decimal__' [
+    [ $: n [ n ] @: __decimal__ this ] @: foos
+    [ $: __decimal__ this ] @: wrap
     100 foos wrap 0 + 100 assert=
   ]
 
-  it should 'support blocks whose __asDecimal__ computes & leaves block which implements __asDecimal__' [
-    [ $: n [ n ] @: __asDecimal__ this ] @: foos
-    [ $: n [ n foos ] @: __asDecimal__ this ] @: wrap
+  it should 'support blocks whose __decimal__ computes & leaves block which implements __decimal__' [
+    [ $: n [ n ] @: __decimal__ this ] @: foos
+    [ $: n [ n foos ] @: __decimal__ this ] @: wrap
     100 foos 0 + 100 assert=
   ]
 
-  it should 'die when same type left in __asDecimal__' [
-    [ $: n [ n foos ] @: __asDecimal__ this ] @: foos
-    [ 100 foos 200 foos + ] 'bad engine depth: maybe deep recursion in __as...__?' assertDies
+  it should 'die when same type left in __decimal__' [
+    [ $: n [ n foos ] @: __decimal__ this ] @: foos
+    [ 100 foos 200 foos + ] 'bad engine depth: deep recursion in a __metaword__?' assertDies
   ]
 ]

--- a/tests/decimal.nk
+++ b/tests/decimal.nk
@@ -84,8 +84,8 @@ describe 'Math: inter-domain decimal math' [
     1 '2' +
   ]
 
-  it should 'try to convert type block arguments to decimals via *asDecimal' [
-    [ $: *asDecimal this ] @: foos
+  it should 'try to convert type block arguments to decimals via __asDecimal__' [
+    [ $: __asDecimal__ this ] @: foos
     100 foos 200 foos + 300 assert=
   ]
 
@@ -156,42 +156,42 @@ describe 'Math: floating point (precise) math' [
   ]
 ]
 
-describe '*asDecimal hook for implicit conversion of blocks to decimals' [
+describe '__asDecimal__ hook for implicit conversion of blocks to decimals' [
   in lang
 
-  it dies 'when block does not implement *asDecimal' [
+  it dies 'when block does not implement __asDecimal__' [
     1 [ ] +
   ]
 
-  it should 'support blocks which implement *asDecimal literally' [
-    [ $: *asDecimal this ] @: wrap
+  it should 'support blocks which implement __asDecimal__ literally' [
+    [ $: __asDecimal__ this ] @: wrap
     1 2 wrap + 3 assert=
   ]
 
-  it should 'support blocks which implement *asDecimal computationally' [
-    [ $: value [ value dup * ] @: *asDecimal this ] @: squareWrap
+  it should 'support blocks which implement __asDecimal__ computationally' [
+    [ $: value [ value dup * ] @: __asDecimal__ this ] @: squareWrap
     1 2 squareWrap + 5 assert=
   ]
 
-  it dies 'when block does not return a decimal in *asDecimal' [
-    [ toQuote $: *asDecimal this ] @: wrap
+  it dies 'when block does not return a decimal in __asDecimal__' [
+    [ toQuote $: __asDecimal__ this ] @: wrap
     1 2 wrap +
   ]
 
-  it should 'support blocks whose *asDecimal leaves block which implements *asDecimal' [
-    [ $: n [ n ] @: *asDecimal this ] @: foos
-    [ $: *asDecimal this ] @: wrap
+  it should 'support blocks whose __asDecimal__ leaves block which implements __asDecimal__' [
+    [ $: n [ n ] @: __asDecimal__ this ] @: foos
+    [ $: __asDecimal__ this ] @: wrap
     100 foos wrap 0 + 100 assert=
   ]
 
-  it should 'support blocks whose *asDecimal computes & leaves block which implements *asDecimal' [
-    [ $: n [ n ] @: *asDecimal this ] @: foos
-    [ $: n [ n foos ] @: *asDecimal this ] @: wrap
+  it should 'support blocks whose __asDecimal__ computes & leaves block which implements __asDecimal__' [
+    [ $: n [ n ] @: __asDecimal__ this ] @: foos
+    [ $: n [ n foos ] @: __asDecimal__ this ] @: wrap
     100 foos 0 + 100 assert=
   ]
 
-  it should 'die when same type left in *asDecimal' [
-    [ $: n [ n foos ] @: *asDecimal this ] @: foos
-    [ 100 foos 200 foos + ] 'bad engine depth: maybe deep recursion in *as...?' assertDies
+  it should 'die when same type left in __asDecimal__' [
+    [ $: n [ n foos ] @: __asDecimal__ this ] @: foos
+    [ 100 foos 200 foos + ] 'bad engine depth: maybe deep recursion in __as...__?' assertDies
   ]
 ]

--- a/tests/essential.nk
+++ b/tests/essential.nk
@@ -311,9 +311,9 @@ describe 'word?' [
   in lang
 
   it should 'leave true for word' [ #foo word? true assert= ]
-  it should 'leave true for block implementing *asWord' [
-    [ #foo  $: *asWord this ] @: x
-    [ [ x ] @: *asWord this ] @: y
+  it should 'leave true for block implementing __asWord__' [
+    [ #foo  $: __asWord__ this ] @: x
+    [ [ x ] @: __asWord__ this ] @: y
     x word? true assert=
     y word? true assert=
   ]
@@ -342,9 +342,9 @@ describe 'quotedWord?' [
   in lang
 
   it should 'leave true for quoted word' [ ##foo quotedWord? true assert= ]
-  it should 'leave true for block implementing *asQuotedWord' [
-    [ ##foo $: *asQuotedWord this ] @: x
-    [ [ x ] @: *asQuotedWord this ] @: y
+  it should 'leave true for block implementing __asQuotedWord__' [
+    [ ##foo $: __asQuotedWord__ this ] @: x
+    [ [ x ] @: __asQuotedWord__ this ] @: y
     x quotedWord? true assert=
     y quotedWord? true assert=
   ]
@@ -362,9 +362,9 @@ describe 'decimal?' [
   in lang
 
   it should 'leave true for decimal' [ 100 decimal? true assert= ]
-  it should 'leave true for block implementing *asDecimal' [
-    [ 100   $: *asDecimal this ] @: x
-    [ [ x ] @: *asDecimal this ] @: y
+  it should 'leave true for block implementing __asDecimal__' [
+    [ 100   $: __asDecimal__ this ] @: x
+    [ [ x ] @: __asDecimal__ this ] @: y
     x decimal? true assert=
     y decimal? true assert=
   ]
@@ -382,9 +382,9 @@ describe 'quote?' [
   in lang
 
   it should 'leave true for quote' [ 'foo' quote? true assert= ]
-  it should 'leave true for block implementing *asQuote' [
-    [ 'foo' $: *asQuote this ] @: x
-    [ [ x ] @: *asQuote this ] @: y
+  it should 'leave true for block implementing __asQuote__' [
+    [ 'foo' $: __asQuote__ this ] @: x
+    [ [ x ] @: __asQuote__ this ] @: y
     x quote? true assert=
     y quote? true assert=
   ]
@@ -402,9 +402,9 @@ describe 'boolean?' [
   in lang
 
   it should 'leave true for boolean' [ true boolean? true assert= ]
-  it should 'leave true for block implementing *asBoolean' [
-    [ true  $: *asBoolean this ] @: x
-    [ [ x ] @: *asBoolean this ] @: y
+  it should 'leave true for block implementing __asBoolean__' [
+    [ true  $: __asBoolean__ this ] @: x
+    [ [ x ] @: __asBoolean__ this ] @: y
     x boolean? true assert=
     y boolean? true assert=
   ]
@@ -422,9 +422,9 @@ describe 'color?' [
   in lang
 
   it should 'leave true for color' [ 0 0 0 rgb color? true assert= ]
-  it should 'leave true for block implementing *asColor' [
-    [ 0 0 0 rgb $: *asColor this ] @: x
-    [ [ x ] @: *asColor this ] @: y
+  it should 'leave true for block implementing __asColor__' [
+    [ 0 0 0 rgb $: __asColor__ this ] @: x
+    [ [ x ] @: __asColor__ this ] @: y
     x color? true assert=
     y color? true assert=
   ]
@@ -443,9 +443,9 @@ describe 'byteslice?' [
   in lang
 
   it should 'leave true for byteslice' [ 'hello world' toByteslice byteslice? true assert= ]
-  it should 'leave true for block implementing *asByteslice' [
-    [ 'hello' toByteslice $: *asByteslice this ] @: x
-    [ [ x ] @: *asByteslice this ] @: y
+  it should 'leave true for block implementing __asByteslice__' [
+    [ 'hello' toByteslice $: __asByteslice__ this ] @: x
+    [ [ x ] @: __asByteslice__ this ] @: y
     x byteslice? true assert=
     y byteslice? true assert=
   ]
@@ -472,14 +472,14 @@ describe 'asDecimal' [
     100 dup asDecimal assert=
   ]
 
-  [ $: x x $: *asDecimal this ] @: a
+  [ $: x x $: __asDecimal__ this ] @: a
 
-  it dies 'when given quote in *asDecimal' [ 'foo' a asDecimal ]
-  it dies 'when given word in *asDecimal' [ #foo a asDecimal ]
-  it dies 'when given quoted word in *asDecimal' [ ##foo a asDecimal ]
-  it dies 'when given boolean in *asDecimal' [ true a asDecimal ]
-  it dies 'when given block in *asDecimal' [ [] a asDecimal ]
-  it should 'leave instance when given decimal in *asDecimal' [
+  it dies 'when given quote in __asDecimal__' [ 'foo' a asDecimal ]
+  it dies 'when given word in __asDecimal__' [ #foo a asDecimal ]
+  it dies 'when given quoted word in __asDecimal__' [ ##foo a asDecimal ]
+  it dies 'when given boolean in __asDecimal__' [ true a asDecimal ]
+  it dies 'when given block in __asDecimal__' [ [] a asDecimal ]
+  it should 'leave instance when given decimal in __asDecimal__' [
     100 a dup asDecimal same? true assert=
   ]
 ]
@@ -496,14 +496,14 @@ describe 'asQuote' [
     'foo' dup asQuote assert=
   ]
 
-  [ $: x x $: *asQuote this ] @: a
+  [ $: x x $: __asQuote__ this ] @: a
 
-  it dies 'when given decimal in *asQuote' [ 100 a asQuote ]
-  it dies 'when given word in *asQuote' [ #foo a asQuote ]
-  it dies 'when given quoted word in *asQuote' [ ##foo a asQuote ]
-  it dies 'when given boolean in *asQuote' [ true a asQuote ]
-  it dies 'when given block in *asQuote' [ [] a asQuote ]
-  it should 'leave instance when given quote in *asQuote' [
+  it dies 'when given decimal in __asQuote__' [ 100 a asQuote ]
+  it dies 'when given word in __asQuote__' [ #foo a asQuote ]
+  it dies 'when given quoted word in __asQuote__' [ ##foo a asQuote ]
+  it dies 'when given boolean in __asQuote__' [ true a asQuote ]
+  it dies 'when given block in __asQuote__' [ [] a asQuote ]
+  it should 'leave instance when given quote in __asQuote__' [
     'foo' a dup asQuote same? true assert=
   ]
 ]
@@ -520,14 +520,14 @@ describe 'asWord' [
     #foo dup asWord assert=
   ]
 
-  [ $: x x $: *asWord this ] @: a
+  [ $: x x $: __asWord__ this ] @: a
 
-  it dies 'when given decimal in *asWord' [ 100 a asWord ]
-  it dies 'when given quote in *asWord' [ 'foo' a asWord ]
-  it dies 'when given quoted word in *asWord' [ ##foo a asWord ]
-  it dies 'when given boolean in *asWord' [ true a asWord ]
-  it dies 'when given block in *asWord' [ [] a asWord ]
-  it should 'leave instance when given word in *asWord' [
+  it dies 'when given decimal in __asWord__' [ 100 a asWord ]
+  it dies 'when given quote in __asWord__' [ 'foo' a asWord ]
+  it dies 'when given quoted word in __asWord__' [ ##foo a asWord ]
+  it dies 'when given boolean in __asWord__' [ true a asWord ]
+  it dies 'when given block in __asWord__' [ [] a asWord ]
+  it should 'leave instance when given word in __asWord__' [
     #foo a dup asWord same? true assert=
   ]
 ]
@@ -544,14 +544,14 @@ describe 'asQuotedWord' [
     ##foo dup asQuotedWord assert=
   ]
 
-  [ $: x x $: *asQuotedWord this ] @: a
+  [ $: x x $: __asQuotedWord__ this ] @: a
 
-  it dies 'when given decimal in *asQuotedWord' [ 100 a asQuotedWord ]
-  it dies 'when given quote in *asQuotedWord' [ 'foo' a asQuotedWord ]
-  it dies 'when given word in *asQuotedWord' [ #foo a asQuotedWord ]
-  it dies 'when given boolean in *asQuotedWord' [ true a asQuotedWord ]
-  it dies 'when given block in *asQuotedWord' [ [] a asQuotedWord ]
-  it should 'leave instance when given quoted word in *asQuotedWord' [
+  it dies 'when given decimal in __asQuotedWord__' [ 100 a asQuotedWord ]
+  it dies 'when given quote in __asQuotedWord__' [ 'foo' a asQuotedWord ]
+  it dies 'when given word in __asQuotedWord__' [ #foo a asQuotedWord ]
+  it dies 'when given boolean in __asQuotedWord__' [ true a asQuotedWord ]
+  it dies 'when given block in __asQuotedWord__' [ [] a asQuotedWord ]
+  it should 'leave instance when given quoted word in __asQuotedWord__' [
     ##foo a dup asQuotedWord same? true assert=
   ]
 ]
@@ -568,14 +568,14 @@ describe 'asBoolean' [
     true dup asBoolean assert=
   ]
 
-  [ $: x x $: *asBoolean this ] @: a
+  [ $: x x $: __asBoolean__ this ] @: a
 
-  it dies 'when given decimal in *asBoolean' [ 100 a asBoolean ]
-  it dies 'when given quote in *asBoolean' [ 'foo' a asBoolean ]
-  it dies 'when given word in *asBoolean' [ #foo a asBoolean ]
-  it dies 'when given quoted word in *asBoolean' [ ##foo a asBoolean ]
-  it dies 'when given block in *asBoolean' [ [] a asBoolean ]
-  it should 'leave instance when given boolean in *asBoolean' [
+  it dies 'when given decimal in __asBoolean__' [ 100 a asBoolean ]
+  it dies 'when given quote in __asBoolean__' [ 'foo' a asBoolean ]
+  it dies 'when given word in __asBoolean__' [ #foo a asBoolean ]
+  it dies 'when given quoted word in __asBoolean__' [ ##foo a asBoolean ]
+  it dies 'when given block in __asBoolean__' [ [] a asBoolean ]
+  it should 'leave instance when given boolean in __asBoolean__' [
     true a dup asBoolean same? true assert=
   ]
 ]
@@ -595,8 +595,8 @@ describe 'asByteslice' [
   ]
 
 
-  it should 'it should accept block with *asByteslice' [
-    [ $: x x $: *asByteslice this ] @: a
+  it should 'it should accept block with __asByteslice__' [
+    [ $: x x $: __asByteslice__ this ] @: a
 
     [ 100 a asByteslice ] 'bad type: decimal, expected: a byteslice' assertDies
     [ 'foo' a asByteslice ] 'bad type: quote, expected: a byteslice' assertDies
@@ -689,7 +689,7 @@ describe 'toQuote block' [
   ]
 
   it should 'respect quote reprs' [
-    [ 'fooBar' $: *asQuote ] obj $: x
+    [ 'fooBar' $: __asQuote__ ] obj $: x
     x toQuote 'fooBar' assert=
     x enclose toQuote '[ fooBar ]' assert=
   ]
@@ -773,20 +773,20 @@ describe 'color?' [
     [ ] color? false assert= "...etc.."
   ]
 
-  it should 'leave false for block implementing *asColor' [
-    [   0 0 0 rgb  $: *asColor this ] $: x
-    [ [ 0 0 0 rgb] @: *asColor this ] $: y
+  it should 'leave false for block implementing __asColor__' [
+    [   0 0 0 rgb  $: __asColor__ this ] $: x
+    [ [ 0 0 0 rgb] @: __asColor__ this ] $: y
     x color? false assert=
     y color? false assert=
   ]
 
-  [ $: x x $: *asColor this ] @: a
+  [ $: x x $: __asColor__ this ] @: a
 
-  it should 'leave instance when given color in *asColor' [
+  it should 'leave instance when given color in __asColor__' [
     0 0 0 rgb a dup asColor same? true assert=
   ]
 
-  it should 'die when not given color in *asColor' [
+  it should 'die when not given color in __asColor__' [
     [ 'foo' a asColor ] 'bad type: quote, expected: a color' assertDies
   ]
 ]

--- a/tests/essential.nk
+++ b/tests/essential.nk
@@ -311,9 +311,9 @@ describe 'word?' [
   in lang
 
   it should 'leave true for word' [ #foo word? true assert= ]
-  it should 'leave true for block implementing __asWord__' [
-    [ #foo  $: __asWord__ this ] @: x
-    [ [ x ] @: __asWord__ this ] @: y
+  it should 'leave true for block implementing __word__' [
+    [ #foo  $: __word__ this ] @: x
+    [ [ x ] @: __word__ this ] @: y
     x word? true assert=
     y word? true assert=
   ]
@@ -342,9 +342,9 @@ describe 'quotedWord?' [
   in lang
 
   it should 'leave true for quoted word' [ ##foo quotedWord? true assert= ]
-  it should 'leave true for block implementing __asQuotedWord__' [
-    [ ##foo $: __asQuotedWord__ this ] @: x
-    [ [ x ] @: __asQuotedWord__ this ] @: y
+  it should 'leave true for block implementing __quotedword__' [
+    [ ##foo $: __quotedword__ this ] @: x
+    [ [ x ] @: __quotedword__ this ] @: y
     x quotedWord? true assert=
     y quotedWord? true assert=
   ]
@@ -362,9 +362,9 @@ describe 'decimal?' [
   in lang
 
   it should 'leave true for decimal' [ 100 decimal? true assert= ]
-  it should 'leave true for block implementing __asDecimal__' [
-    [ 100   $: __asDecimal__ this ] @: x
-    [ [ x ] @: __asDecimal__ this ] @: y
+  it should 'leave true for block implementing __decimal__' [
+    [ 100   $: __decimal__ this ] @: x
+    [ [ x ] @: __decimal__ this ] @: y
     x decimal? true assert=
     y decimal? true assert=
   ]
@@ -382,9 +382,9 @@ describe 'quote?' [
   in lang
 
   it should 'leave true for quote' [ 'foo' quote? true assert= ]
-  it should 'leave true for block implementing __asQuote__' [
-    [ 'foo' $: __asQuote__ this ] @: x
-    [ [ x ] @: __asQuote__ this ] @: y
+  it should 'leave true for block implementing __quote__' [
+    [ 'foo' $: __quote__ this ] @: x
+    [ [ x ] @: __quote__ this ] @: y
     x quote? true assert=
     y quote? true assert=
   ]
@@ -402,9 +402,9 @@ describe 'boolean?' [
   in lang
 
   it should 'leave true for boolean' [ true boolean? true assert= ]
-  it should 'leave true for block implementing __asBoolean__' [
-    [ true  $: __asBoolean__ this ] @: x
-    [ [ x ] @: __asBoolean__ this ] @: y
+  it should 'leave true for block implementing __boolean__' [
+    [ true  $: __boolean__ this ] @: x
+    [ [ x ] @: __boolean__ this ] @: y
     x boolean? true assert=
     y boolean? true assert=
   ]
@@ -422,9 +422,9 @@ describe 'color?' [
   in lang
 
   it should 'leave true for color' [ 0 0 0 rgb color? true assert= ]
-  it should 'leave true for block implementing __asColor__' [
-    [ 0 0 0 rgb $: __asColor__ this ] @: x
-    [ [ x ] @: __asColor__ this ] @: y
+  it should 'leave true for block implementing __color__' [
+    [ 0 0 0 rgb $: __color__ this ] @: x
+    [ [ x ] @: __color__ this ] @: y
     x color? true assert=
     y color? true assert=
   ]
@@ -443,9 +443,9 @@ describe 'byteslice?' [
   in lang
 
   it should 'leave true for byteslice' [ 'hello world' toByteslice byteslice? true assert= ]
-  it should 'leave true for block implementing __asByteslice__' [
-    [ 'hello' toByteslice $: __asByteslice__ this ] @: x
-    [ [ x ] @: __asByteslice__ this ] @: y
+  it should 'leave true for block implementing __byteslice__' [
+    [ 'hello' toByteslice $: __byteslice__ this ] @: x
+    [ [ x ] @: __byteslice__ this ] @: y
     x byteslice? true assert=
     y byteslice? true assert=
   ]
@@ -472,14 +472,14 @@ describe 'asDecimal' [
     100 dup asDecimal assert=
   ]
 
-  [ $: x x $: __asDecimal__ this ] @: a
+  [ $: x x $: __decimal__ this ] @: a
 
-  it dies 'when given quote in __asDecimal__' [ 'foo' a asDecimal ]
-  it dies 'when given word in __asDecimal__' [ #foo a asDecimal ]
-  it dies 'when given quoted word in __asDecimal__' [ ##foo a asDecimal ]
-  it dies 'when given boolean in __asDecimal__' [ true a asDecimal ]
-  it dies 'when given block in __asDecimal__' [ [] a asDecimal ]
-  it should 'leave instance when given decimal in __asDecimal__' [
+  it dies 'when given quote in __decimal__' [ 'foo' a asDecimal ]
+  it dies 'when given word in __decimal__' [ #foo a asDecimal ]
+  it dies 'when given quoted word in __decimal__' [ ##foo a asDecimal ]
+  it dies 'when given boolean in __decimal__' [ true a asDecimal ]
+  it dies 'when given block in __decimal__' [ [] a asDecimal ]
+  it should 'leave instance when given decimal in __decimal__' [
     100 a dup asDecimal same? true assert=
   ]
 ]
@@ -496,14 +496,14 @@ describe 'asQuote' [
     'foo' dup asQuote assert=
   ]
 
-  [ $: x x $: __asQuote__ this ] @: a
+  [ $: x x $: __quote__ this ] @: a
 
-  it dies 'when given decimal in __asQuote__' [ 100 a asQuote ]
-  it dies 'when given word in __asQuote__' [ #foo a asQuote ]
-  it dies 'when given quoted word in __asQuote__' [ ##foo a asQuote ]
-  it dies 'when given boolean in __asQuote__' [ true a asQuote ]
-  it dies 'when given block in __asQuote__' [ [] a asQuote ]
-  it should 'leave instance when given quote in __asQuote__' [
+  it dies 'when given decimal in __quote__' [ 100 a asQuote ]
+  it dies 'when given word in __quote__' [ #foo a asQuote ]
+  it dies 'when given quoted word in __quote__' [ ##foo a asQuote ]
+  it dies 'when given boolean in __quote__' [ true a asQuote ]
+  it dies 'when given block in __quote__' [ [] a asQuote ]
+  it should 'leave instance when given quote in __quote__' [
     'foo' a dup asQuote same? true assert=
   ]
 ]
@@ -520,14 +520,14 @@ describe 'asWord' [
     #foo dup asWord assert=
   ]
 
-  [ $: x x $: __asWord__ this ] @: a
+  [ $: x x $: __word__ this ] @: a
 
-  it dies 'when given decimal in __asWord__' [ 100 a asWord ]
-  it dies 'when given quote in __asWord__' [ 'foo' a asWord ]
-  it dies 'when given quoted word in __asWord__' [ ##foo a asWord ]
-  it dies 'when given boolean in __asWord__' [ true a asWord ]
-  it dies 'when given block in __asWord__' [ [] a asWord ]
-  it should 'leave instance when given word in __asWord__' [
+  it dies 'when given decimal in __word__' [ 100 a asWord ]
+  it dies 'when given quote in __word__' [ 'foo' a asWord ]
+  it dies 'when given quoted word in __word__' [ ##foo a asWord ]
+  it dies 'when given boolean in __word__' [ true a asWord ]
+  it dies 'when given block in __word__' [ [] a asWord ]
+  it should 'leave instance when given word in __word__' [
     #foo a dup asWord same? true assert=
   ]
 ]
@@ -544,14 +544,14 @@ describe 'asQuotedWord' [
     ##foo dup asQuotedWord assert=
   ]
 
-  [ $: x x $: __asQuotedWord__ this ] @: a
+  [ $: x x $: __quotedword__ this ] @: a
 
-  it dies 'when given decimal in __asQuotedWord__' [ 100 a asQuotedWord ]
-  it dies 'when given quote in __asQuotedWord__' [ 'foo' a asQuotedWord ]
-  it dies 'when given word in __asQuotedWord__' [ #foo a asQuotedWord ]
-  it dies 'when given boolean in __asQuotedWord__' [ true a asQuotedWord ]
-  it dies 'when given block in __asQuotedWord__' [ [] a asQuotedWord ]
-  it should 'leave instance when given quoted word in __asQuotedWord__' [
+  it dies 'when given decimal in __quotedword__' [ 100 a asQuotedWord ]
+  it dies 'when given quote in __quotedword__' [ 'foo' a asQuotedWord ]
+  it dies 'when given word in __quotedword__' [ #foo a asQuotedWord ]
+  it dies 'when given boolean in __quotedword__' [ true a asQuotedWord ]
+  it dies 'when given block in __quotedword__' [ [] a asQuotedWord ]
+  it should 'leave instance when given quoted word in __quotedword__' [
     ##foo a dup asQuotedWord same? true assert=
   ]
 ]
@@ -568,14 +568,14 @@ describe 'asBoolean' [
     true dup asBoolean assert=
   ]
 
-  [ $: x x $: __asBoolean__ this ] @: a
+  [ $: x x $: __boolean__ this ] @: a
 
-  it dies 'when given decimal in __asBoolean__' [ 100 a asBoolean ]
-  it dies 'when given quote in __asBoolean__' [ 'foo' a asBoolean ]
-  it dies 'when given word in __asBoolean__' [ #foo a asBoolean ]
-  it dies 'when given quoted word in __asBoolean__' [ ##foo a asBoolean ]
-  it dies 'when given block in __asBoolean__' [ [] a asBoolean ]
-  it should 'leave instance when given boolean in __asBoolean__' [
+  it dies 'when given decimal in __boolean__' [ 100 a asBoolean ]
+  it dies 'when given quote in __boolean__' [ 'foo' a asBoolean ]
+  it dies 'when given word in __boolean__' [ #foo a asBoolean ]
+  it dies 'when given quoted word in __boolean__' [ ##foo a asBoolean ]
+  it dies 'when given block in __boolean__' [ [] a asBoolean ]
+  it should 'leave instance when given boolean in __boolean__' [
     true a dup asBoolean same? true assert=
   ]
 ]
@@ -595,8 +595,8 @@ describe 'asByteslice' [
   ]
 
 
-  it should 'it should accept block with __asByteslice__' [
-    [ $: x x $: __asByteslice__ this ] @: a
+  it should 'it should accept block with __byteslice__' [
+    [ $: x x $: __byteslice__ this ] @: a
 
     [ 100 a asByteslice ] 'bad type: decimal, expected: a byteslice' assertDies
     [ 'foo' a asByteslice ] 'bad type: quote, expected: a byteslice' assertDies
@@ -689,7 +689,7 @@ describe 'toQuote block' [
   ]
 
   it should 'respect quote reprs' [
-    [ 'fooBar' $: __asQuote__ ] obj $: x
+    [ 'fooBar' $: __quote__ ] obj $: x
     x toQuote 'fooBar' assert=
     x enclose toQuote '[ fooBar ]' assert=
   ]
@@ -773,20 +773,20 @@ describe 'color?' [
     [ ] color? false assert= "...etc.."
   ]
 
-  it should 'leave false for block implementing __asColor__' [
-    [   0 0 0 rgb  $: __asColor__ this ] $: x
-    [ [ 0 0 0 rgb] @: __asColor__ this ] $: y
+  it should 'leave false for block implementing __color__' [
+    [   0 0 0 rgb  $: __color__ this ] $: x
+    [ [ 0 0 0 rgb] @: __color__ this ] $: y
     x color? false assert=
     y color? false assert=
   ]
 
-  [ $: x x $: __asColor__ this ] @: a
+  [ $: x x $: __color__ this ] @: a
 
-  it should 'leave instance when given color in __asColor__' [
+  it should 'leave instance when given color in __color__' [
     0 0 0 rgb a dup asColor same? true assert=
   ]
 
-  it should 'die when not given color in __asColor__' [
+  it should 'die when not given color in __color__' [
     [ 'foo' a asColor ] 'bad type: quote, expected: a color' assertDies
   ]
 ]

--- a/tests/semantics.nk
+++ b/tests/semantics.nk
@@ -171,13 +171,13 @@ describe 'Engine recursion handling' [
   in lang
 
   it should 'die when engine recursion limit is exceeded' [
-    [ [ bI ] @: __asDecimal__ this ] @: a
-    [ [ aI ] @: __asDecimal__ this ] @: b
+    [ [ bI ] @: __decimal__ this ] @: a
+    [ [ aI ] @: __decimal__ this ] @: b
 
     a $: aI
     b $: bI
 
-    [ aI bI + ] 'bad engine depth: maybe deep recursion in __as...__?' assertDies
+    [ aI bI + ] 'bad engine depth: deep recursion in a __metaword__?' assertDies
   ]
 ]
 
@@ -204,7 +204,7 @@ describe 'Block metawords' [
         controlledStack cherry
       ] @: __cherry__
 
-      [ [ '<controlled stack: ' controlledStack '>' ] ~* ] @: __asQuote__
+      [ [ '<controlled stack: ' controlledStack '>' ] ~* ] @: __quote__
     ] obj $: b
 
     b [ 1 2 drop 3 ] there
@@ -230,7 +230,7 @@ describe 'Metawords capability inheritance' [
       [
         qPath disk:read $: qDecimal
         qDecimal parseDecimal
-      ] @: __asDecimal__
+      ] @: __decimal__
 
       [
         nip self 1 + swap open "remove original form, shove self decimal + 1"

--- a/tests/semantics.nk
+++ b/tests/semantics.nk
@@ -70,7 +70,7 @@ describe 'block friends' [
     foo a unfriend
     foo #open 2enclose this reparent
     "^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ demonic crap related to
-      *died precedence. Maybe fixable, maybe not."
+      __died__ precedence. Maybe fixable, maybe not."
       'no value form for \'bar\'' assertDies
   ]
 
@@ -171,13 +171,13 @@ describe 'Engine recursion handling' [
   in lang
 
   it should 'die when engine recursion limit is exceeded' [
-    [ [ bI ] @: *asDecimal this ] @: a
-    [ [ aI ] @: *asDecimal this ] @: b
+    [ [ bI ] @: __asDecimal__ this ] @: a
+    [ [ aI ] @: __asDecimal__ this ] @: b
 
     a $: aI
     b $: bI
 
-    [ aI bI + ] 'bad engine depth: maybe deep recursion in *as...?' assertDies
+    [ aI bI + ] 'bad engine depth: maybe deep recursion in __as...__?' assertDies
   ]
 ]
 
@@ -194,7 +194,7 @@ describe 'Block metawords' [
           '( F -- ): default *-shove implementation' startsWith? true assert=
 
         controlledStack gulp
-      ] @: *-shove
+      ] @: __shove__
 
       [ "Triggered on cherry from this block."
 
@@ -202,9 +202,9 @@ describe 'Block metawords' [
           '( -- ): default *-cherry implementation' startsWith? true assert=
 
         controlledStack cherry
-      ] @: *-cherry
+      ] @: __cherry__
 
-      [ [ '<controlled stack: ' controlledStack '>' ] ~* ] @: *asQuote
+      [ [ '<controlled stack: ' controlledStack '>' ] ~* ] @: __asQuote__
     ] obj $: b
 
     b [ 1 2 drop 3 ] there
@@ -230,15 +230,15 @@ describe 'Metawords capability inheritance' [
       [
         qPath disk:read $: qDecimal
         qDecimal parseDecimal
-      ] @: *asDecimal
+      ] @: __asDecimal__
 
       [
         nip self 1 + swap open "remove original form, shove self decimal + 1"
-      ] @: *-shove
+      ] @: __shove__
 
       [
         drop self 1 - "remove original cherry impl; give them self decimal - 1"
-      ] @: *-cherry
+      ] @: __cherry__
 
       this
     ] @: myDecimalOnDisk


### PR DESCRIPTION
E.g. `[ $: *asDecimal this ]` now becomes `[ $: __decimal__ this ]`.

Just a big search&replace.