### PR TITLE
Allow lookup cycles

### DIFF
--- a/env/core/block.nk
+++ b/env/core/block.nk
@@ -386,7 +386,7 @@
   b.y leaves: 200
   ```
   """
-  ahead thruVal dup <| befriend |>
+  ahead thruVal keep: befriend
 ] @: ·>
 
 

--- a/env/core/block.nk
+++ b/env/core/block.nk
@@ -348,6 +348,21 @@
 ] @: adopt
 
 
+[ """( P `--` C -- C ): infix version of `adopt`.
+
+  ```
+  [ 100 $: x ] obj $: a
+  [ 200 $: y ] obj $: b
+
+  (a -- b -- a) drop
+  a -> [x y] leaves: [ [ 100 200 ] ]
+  b -> [x y] leaves: [ [ 100 200 ] ]
+  ```
+  """
+  ahead thruVal adopt
+] @: --
+
+
 [ "( B -- Cb ): leaves an empty Child block for Block. Very
    much like `new`, but doesn't copy the tape and therefore may
    be faster in certain circumstances."

--- a/env/core/block.nk
+++ b/env/core/block.nk
@@ -363,6 +363,33 @@
 ] @: --
 
 
+[ """( B ·> F -- F ): infix version of `befriend` that leaves
+   the *friend* for further chaining.
+
+  ```
+  [ 100 $: x ] obj $: a
+  [ 200 $: y ] obj $: b
+  a ·> b ·> a drop
+
+  a.x leaves: 100
+  a.y leaves: 200
+
+  b.x leaves: 100
+  b.y leaves: 200
+
+  a [ 'Hello World' =: x ] extend
+
+  a.x leaves: 'Hello World'
+  a.y leaves: 200
+
+  b.x leaves: 'Hello World'
+  b.y leaves: 200
+  ```
+  """
+  ahead thruVal dup <| befriend |>
+] @: ·>
+
+
 [ "( B -- Cb ): leaves an empty Child block for Block. Very
    much like `new`, but doesn't copy the tape and therefore may
    be faster in certain circumstances."
@@ -464,6 +491,101 @@
     [ 2drop             ] "Doesnt have, drop T N."
   br
 ] @: fetch:
+
+
+[ """( S B -- S ): extends Source block with entries from the dictionary
+   of Body block, then instantiates Body block, befriends the instance
+   with Source, and opens Body block with an empty stack. When the Body
+   block instance finishes running, extends Source block with entries
+   from the instance. Leaves Source block.
+
+  All complexities and edge cases aside, this word is basically one of
+  the ways to redefine/create/modify an entry through computation and
+  from another, possibly unrelated block (unrelated as in via the block
+  graph, that is).
+
+  **Important**: Source block is not extended with *private entries*
+  of Body block or Body block instance (that is, entries whose name
+  starts with _underscore). However, Body block does get access and
+  is able to reassign private entries of Source block.
+
+  See `extendWith:` for an example.
+  """
+  $: body $: source
+
+  "First and foremost, merge the prototype (ish) dictionary with
+   the dictionary of the source block."
+  source body mergeDicts
+
+  body new $: instance
+
+  instance source befriend
+    "Open manually: create an instance, move its cursor to 0,
+    create a continuation, and hydrate with an empty orphan stack."
+    orphan (instance (dup 0 |to)) hydrate!
+
+    "Merge dictionaries of the instance after opening with source
+    block. Note that mergeDicts does not merge private entries,
+    i.e. entries starting with _underscore!"
+    source instance mergeDicts
+
+  source
+] @: extendWith
+
+
+[ """( S extendWith: B -- S ): infix version of `extendWith`.
+
+  ```
+  [ 100 $: x ] obj $: a
+  [ 200 $: y ] obj $: b
+
+  a ·> b ·> a drop
+
+  a.x a.y leaves: [ 100 200 ]
+  b.x b.y leaves: [ 100 200 ]
+
+  a extendWith: [ [ y y * ] @: x ] drop
+  b extendWith: [ 4 =: y ] drop
+
+  a.x a.y leaves: [ 16 4 ]
+  b.x b.y leaves: [ 16 4 ]
+
+  b extendWith: [ 100 $: y ] drop
+
+  a.x a.y leaves: [ 10000 100 ]
+  b.x b.y leaves: [ 10000 100 ]
+  ```
+  """
+  ahead thruLitBlock extendWith
+] @: extendWith:
+
+
+[ """( S extend: B -- ): an alternative infix version of `extendWith`
+   which doesn't leave anything.
+
+  ```
+  [ 100 $: x ] obj $: a
+  [ 200 $: y ] obj $: b
+
+  a ·> b ·> a drop
+
+  a.x a.y leaves: [ 100 200 ]
+  b.x b.y leaves: [ 100 200 ]
+
+  a extend: [ [ y y * ] @: x ]
+  b extend: [ 4 =: y ]
+
+  a.x a.y leaves: [ 16 4 ]
+  b.x b.y leaves: [ 16 4 ]
+
+  b extend: [ 100 $: y ]
+
+  a.x a.y leaves: [ 10000 100 ]
+  b.x b.y leaves: [ 10000 100 ]
+  ```
+  """
+  ahead thruLitBlock extendWith drop
+] @: extend:
 
 
 [ """( Lb B -- Lb ): slides cursor in List block from left

--- a/env/core/block.nk
+++ b/env/core/block.nk
@@ -495,8 +495,8 @@
 
 [ """( S B -- S ): extends Source block with entries from the dictionary
    of Body block, then instantiates Body block, befriends the instance
-   with Source, and opens Body block with an empty stack. When the Body
-   block instance finishes running, extends Source block with entries
+   with Source block, and opens Body block with an empty stack. When the
+   Body block instance finishes running, extends Source block with entries
    from the instance. Leaves Source block.
 
   All complexities and edge cases aside, this word is basically one of

--- a/env/core/block.nk
+++ b/env/core/block.nk
@@ -520,13 +520,13 @@
   body new $: instance
 
   instance source befriend
-    "Open manually: create an instance, move its cursor to 0,
-    create a continuation, and hydrate with an empty orphan stack."
+    "Open manually: create an instance, move its cursor to 0, create
+     a continuation, and hydrate with an empty orphan stack."
     orphan (instance (dup 0 |to)) hydrate!
 
     "Merge dictionaries of the instance after opening with source
-    block. Note that mergeDicts does not merge private entries,
-    i.e. entries starting with _underscore!"
+     block. Note that mergeDicts does not merge private entries,
+     i.e. entries starting with _underscore!"
     source instance mergeDicts
 
   source

--- a/src/novika.cr
+++ b/src/novika.cr
@@ -21,6 +21,7 @@ struct Set(T)
 end
 
 # Order is important (somewhat)!
+require "./novika/object_pool"
 require "./novika/forms/form"
 require "./novika/image"
 require "./novika/scissors"

--- a/src/novika/capabilities/impl/essential.cr
+++ b/src/novika/capabilities/impl/essential.cr
@@ -1619,25 +1619,12 @@ module Novika::Capabilities::Impl
       end
 
       target.at("reparent", <<-END
-      ( C P -- C ): changes the parent of Child to Parent. Checks
-       for cycles which can hang the interpreter, therefore is
-       O(N) where N is the amount of Parent's ancestors.
+      ( C P -- C ): changes the parent of Child to Parent. Lookup
+       cycles are allowed and handled gracefully.
       END
       ) do |_, stack|
         parent = stack.drop.a(Block)
         child = stack.top.a(Block)
-
-        # TODO: this seems to be too forgiving. Lookup cycles
-        # are pretty dangerous.
-        current = parent
-        while current
-          if current.same?(child)
-            current.die("this reparent introduces a cycle")
-          else
-            current = current.parent?
-          end
-        end
-
         child.parent = parent
       end
 
@@ -1646,7 +1633,8 @@ module Novika::Capabilities::Impl
 
       Friends are asked for word entries after parents, grandparents
       etc. have failed to retrieve them. This recurses, e.g. friends
-      ask their own friends and so on, until the entry is found.
+      ask their own friends and so on, until the entry is found. Lookup
+      cycles are allowed and handled gracefully.
 
       ```
       [ 100 $: x this ] open $: a

--- a/src/novika/capabilities/impl/essential.cr
+++ b/src/novika/capabilities/impl/essential.cr
@@ -1000,6 +1000,30 @@ module Novika::Capabilities::Impl
         Boolean[store.opens?(name)].onto(stack)
       end
 
+      target.at("entry:delete", <<-END
+      ( B N -- ): deletes the entry corresponding to Name form
+       from the dictionary of Block if it exists there. Otherwise,
+       does nothing.
+
+      ```
+      100 $: x
+
+      [ 200 $: x ] obj $: foo
+
+      "'x' of foo shadows 'x' of toplevel block"
+      foo.x leaves: 200
+
+      "Let's try to remove it so it doesn't:"
+      foo #x entry:delete
+      foo.x leaves: 100
+      ```
+      END
+      ) do |_, stack|
+        name = stack.drop
+        block = stack.drop.a(Block)
+        block.delete(name)
+      end
+
       target.at("shallowCopy", <<-END
       ( B -- C ): makes a shallow copy (sub-blocks are not copied)
        of Block's tape and dictionary, and leaves a Copy block with

--- a/src/novika/dict.cr
+++ b/src/novika/dict.cr
@@ -11,6 +11,10 @@ module Novika
     # result.
     abstract def get(name : Form, & : Form -> Entry?) : Entry?
 
+    # Deletes the entry corresponding to *name* form in this
+    # dictionary if it exists. Otherwise, does nothing.
+    abstract def del(name : Form)
+
     # Returns whether this dictionary has an entry corresponding
     # to *name* form.
     abstract def has?(name : Form) : Bool
@@ -76,6 +80,10 @@ module Novika
       end
 
       @store.fetch(name) { yield name }
+    end
+
+    def del(name : Form)
+      @store.delete(name)
     end
 
     def has?(name : Form) : Bool

--- a/src/novika/forms/block.cr
+++ b/src/novika/forms/block.cr
@@ -770,6 +770,13 @@ module Novika
       at Word.new(name), OpenEntry.new Builtin.new(name, desc, code)
     end
 
+    # Deletes the entry corresponding to *name* form from the
+    # dictionary of this block if it exists there. Otherwise,
+    # does nothing.
+    def delete(name : Form)
+      dict.del(name)
+    end
+
     # Schedules this block for execution in *engine* using the
     # safe scheduling method (see `Engine#schedule`). Optionally,
     # a *stack* block may be provided (otherwise, the *engine*'s

--- a/src/novika/forms/block.cr
+++ b/src/novika/forms/block.cr
@@ -123,26 +123,28 @@ module Novika
     # Executes the fetcher callback on the first echelon of
     # *block*, and recurses on the second echelon.
     #
-    # - The first echelon is parents and friends of *block*.
+    # - The first echelon is parents and friends and friends
+    #   of parents of *block*.
     #
-    # - The second echelon is parents and friends of the first
-    #   echelon. This method deeply recurses (via `visit?`) on
-    #   the second echelon, effectively allowing lookup that is
-    #   not limited in terms of depth.
+    # - The second echelon is parents and friends and friends
+    #   of parents of the first echelon. This method deeply
+    #   recurses (via `visit?`) on the second echelon, effectively
+    #   allowing lookup that is not limited in terms of depth.
     private def fetch_in_echelons?(block : Block) : T?
       visited = @@block_map.acquire
 
       begin
         #
-        # 1ST ECHELON: ask parents and friends.
+        # 1ST ECHELON: ask parents and friends and friends
+        # of parents.
         #
         each_connected_to(block, visited) do |each|
           fetch?(each) { |form| return form }
         end
 
         #
-        # 2ND ECHELON: **recurse** on parents and friends of
-        # the 1ST ECHELON.
+        # 2ND ECHELON: **recurse** on parents and friends and
+        # friends of parents of the 1ST ECHELON.
         #
         visited.each_value do |block|
           each_connected_to(block, visited) do |each|

--- a/src/novika/image.cr
+++ b/src/novika/image.cr
@@ -672,7 +672,7 @@ module Novika
         block.tape.each { |form| enter(form) }
         block.dict.each { |key, entry| enter(key); enter(entry.form) }
 
-        block.each_relative { |rel| enter(rel); nil }
+        block.each_relative_fetch { |rel| enter(rel); nil }
         unless block.prototype.same?(block) # save on a recursive call
           enter(block.prototype)
         end

--- a/src/novika/object_pool.cr
+++ b/src/novika/object_pool.cr
@@ -1,0 +1,33 @@
+module Novika
+  # A naïve object pool, inspired by:
+  #
+  # https://gist.github.com/floere/3121579
+  struct ObjectPool(T)
+    def initialize(@create : -> T, @clear : T -> T)
+      @free = {} of UInt64 => T
+      @used = {} of UInt64 => T
+    end
+
+    private def id(obj : T)
+      obj.object_id
+    end
+
+    # Returns a free/new instance of the object.
+    def acquire : T
+      unless kv = @free.shift?
+        obj = @create.call
+        kv = {id(obj), obj}
+      end
+      @used.[]=(*kv)
+    end
+
+    # Clears the given *instance* of the object, and releases
+    # it so that it can be acquired by someone else.
+    def release(obj : T)
+      @clear.call(obj)
+      id = id(obj)
+      @free[id] = obj
+      @used.delete(id)
+    end
+  end
+end

--- a/src/novika/object_pool.cr
+++ b/src/novika/object_pool.cr
@@ -3,6 +3,8 @@ module Novika
   #
   # https://gist.github.com/floere/3121579
   struct ObjectPool(T)
+    # TODO: concurrency: protect with a mutex
+
     def initialize(@create : -> T, @clear : T -> T)
       @free = {} of UInt64 => T
       @used = {} of UInt64 => T

--- a/tests/block.nk
+++ b/tests/block.nk
@@ -411,6 +411,31 @@ describe 'surroundedBy?' [
 ]
 
 
+describe '·>' [
+  in lang
+
+  it should 'function the same as \'befriend\'' [
+    [ 100 $: x ] obj $: a
+    [ 200 $: y ] obj $: b
+    a ·> b ·> a drop
+
+    a.x 100 assert=
+    a.y 200 assert=
+
+    b.x 100 assert=
+    b.y 200 assert=
+
+    a extendWith: [ 'Hello World' =: x ]
+
+    a.x 'Hello World' assert=
+    a.y 200 assert=
+
+    b.x 'Hello World' assert=
+    b.y 200 assert=
+  ]
+]
+
+
 describe 'child' [
   in lang
 
@@ -561,6 +586,151 @@ describe 'fetch:' [
     sumVal open 300 assert=
   ]
 ]
+
+describe 'extendWith' [
+  in lang
+
+  it should 'open the body block' [
+    [ 100 $: x ] obj $: b
+    [ b extendWith: [ 'opened' die ] ] 'opened' assertDies
+
+    stack count 0 assert=
+  ]
+
+  it should 'merge dictionaries of source and body blocks' [
+    [ 100 $: x ] obj $: b
+
+    b.x 100 assert=
+    [ b.y ] 'no value form for \'y\'' assertDies
+
+    [ b extendWith: [ 200 $: y ] ] vals $: s
+    (s count) 1 assert=
+    (s top) b same? true assert=
+
+    b.x 100 assert=
+    b.y 200 assert=
+
+    stack count 0 assert=
+  ]
+
+  it should 'allow to submit into source block' [
+    [ 100 $: x ] obj $: b
+    b.x 100 assert=
+
+    b extendWith: [ 200 =: x ] b same? true assert=
+    b.x 200 assert=
+
+    stack count 0 assert=
+  ]
+
+  it should 'allow to overwrite entry type' [
+    [ [ 1 2 + ] $: x ] obj $: b
+    b.x [ 1 2 + ] assert=
+
+    b extendWith: [ [ 3 4 + ] @: x ] b same? true assert=
+    b.x 7 assert=
+
+    stack count 0 assert=
+  ]
+
+  it should 'keep body block parent/friends the same' [
+    [ 100 $: x ] obj $: a
+    [ 200 $: y ] obj $: b
+
+    123 $: z
+
+    [ x $: a
+      y $: b
+      z $: c ] $: bodyBlock
+
+    bodyBlock ·> a drop
+    bodyBlock ·> b drop
+
+    [ 'a' $: a
+      'b' $: b
+      'c' $: c
+      'd' $: d ] obj extendWith: bodyBlock $: foo
+
+    foo.a 100 assert=
+    foo.b 200 assert=
+    foo.c 123 assert=
+    foo.d 'd' assert=
+
+    stack count 0 assert=
+  ]
+
+  it should 'extend with body block prototype\'s entries' [
+    [ ] extendWith: [ 100 $: x
+                      200 $: y ] $: bb
+
+    bb.x 100 assert=
+    bb.y 200 assert=
+
+    [ 'foo' $: c ] obj extendWith: bb $: foo1
+    foo1.x 100 assert=
+    foo1.y 200 assert=
+    foo1.c 'foo' assert=
+
+    [ x y + $: c ] bb resub
+
+    [ 'foo' $: c ] obj extendWith: bb $: foo2
+    foo2.x 100 assert=
+    foo2.y 200 assert=
+    foo2.c 300 assert=
+
+    stack count 0 assert=
+  ]
+
+  it should 'run example from docs' [
+    [ 100 $: x ] obj $: a
+    [ 200 $: y ] obj $: b
+
+    a ·> b ·> a drop
+
+    [ a.x a.y ] vals [ 100 200 ] assert=
+    [ b.x b.y ] vals [ 100 200 ] assert=
+
+    a extendWith: [ [ y y * ] @: x ] drop
+    b extendWith: [ 4 =: y ] drop
+
+    [ a.x a.y ] vals [ 16 4 ] assert=
+    [ b.x b.y ] vals [ 16 4 ] assert=
+
+    b extendWith: [ 100 $: y ] drop
+
+    [ a.x a.y ] vals [ 10000 100 ] assert=
+    [ b.x b.y ] vals [ 10000 100 ] assert=
+
+    stack count 0 assert=
+  ]
+]
+
+
+describe 'extend:' [
+  in lang
+
+  it should 'work like \'extendWith:\' but keep the stack clean' [
+    [ 100 $: x ] obj $: a
+    [ 200 $: y ] obj $: b
+
+    a ·> b ·> a drop
+
+    [ a.x a.y ] vals [ 100 200 ] assert=
+    [ b.x b.y ] vals [ 100 200 ] assert=
+
+    a extend: [ [ y y * ] @: x ]
+    b extend: [ 4 =: y ]
+
+    [ a.x a.y ] vals [ 16 4 ] assert=
+    [ b.x b.y ] vals [ 16 4 ] assert=
+
+    b extend: [ 100 $: y ]
+
+    [ a.x a.y ] vals [ 10000 100 ] assert=
+    [ b.x b.y ] vals [ 10000 100 ] assert=
+  ]
+]
+
 
 describe '|slideRight' [
   in lang

--- a/tests/essential.nk
+++ b/tests/essential.nk
@@ -232,6 +232,57 @@ describe 'toOrphan' [
 ]
 
 
+"TODO: test: entry:submit entry:exists? entry:fetch entry:fetch? entry:open entry:flatFetch? entry:isOpenEntry?"
+
+
+describe 'entry:delete' [
+  in lang
+
+  it should 'delete the entry corresponding to name form' [
+    'hello world' $: z
+
+    [ 100 $: x
+      200 $: y ] obj $: point
+
+    point.x 100 assert=
+    point.y 200 assert=
+
+    point #x entry:delete
+    [ point.x ] 'no value form for \'x\'' assertDies
+    point.y 200 assert=
+
+    point #y entry:delete
+    [ point.x ] 'no value form for \'x\'' assertDies
+    [ point.y ] 'no value form for \'y\'' assertDies
+
+    point #z entry:delete
+
+    z 'hello world' assert=
+
+    this #z entry:delete
+
+    [ z ] 'definition for z not found in the enclosing block(s)' assertDies
+
+    stack count 0 assert=
+  ]
+
+  it should 'run the example from docs' [
+    100 $: x
+
+    [ 200 $: x ] obj $: foo
+
+    "'x' of foo shadows 'x' of toplevel block"
+    foo.x 200 assert=
+
+    "Let's try to remove it so it doesn't:"
+    foo #x entry:delete
+    foo.x 100 assert=
+
+    stack count 0 assert=
+  ]
+]
+
+
 describe 'shallowCopy' [
   in lang
 

--- a/tests/essential.nk
+++ b/tests/essential.nk
@@ -283,6 +283,30 @@ describe 'entry:delete' [
 ]
 
 
+describe 'entry:pathTo?' [
+  in lang
+
+  it should 'run the example from docs' [
+    [ 100 $: x  'a' $: __quote__ ] obj $: a
+    [ 200 $: y  'b' $: __quote__ ] obj $: b
+    [ 300 $: z  'c' $: __quote__ ] obj $: c
+
+    a -- b -- c drop
+
+    [ a #x entry:pathTo? ] vals sepBy: ' ' '[ a ] 100 true' assert=
+    [ b #x entry:pathTo? ] vals sepBy: ' ' '[ b a ] 100 true' assert=
+    [ c #x entry:pathTo? ] vals sepBy: ' ' '[ c b a ] 100 true' assert=
+
+    [ b #y entry:pathTo? ] vals sepBy: ' ' '[ b ] 200 true' assert=
+    [ c #y entry:pathTo? ] vals sepBy: ' ' '[ c b ] 200 true' assert=
+
+    [ c #z entry:pathTo? ] vals sepBy: ' ' '[ c ] 300 true' assert=
+
+    [ c #foo entry:pathTo? ] vals sepBy: ' ' 'false' assert=
+  ]
+]
+
+
 describe 'shallowCopy' [
   in lang
 

--- a/tests/semantics.nk
+++ b/tests/semantics.nk
@@ -53,6 +53,62 @@ describe 'essential lookup' [
 
     a.inc 101 assert=
   ]
+
+  it should 'allow more involved lookup/friend cycles' [
+    [ 100 $: x [ [ x y z ] here sum ] @: perform ] obj $: a
+    [ 200 $: y [ [ x y z ] here product ] @: perform ] obj $: b
+    [ 300 $: z ] obj $: c
+
+    """
+    +-------+
+    |       |
+    |    +--+--+
+    | +->+  A  +----+
+    | |  +--+--+    |
+    | |     ^       |
+    | |     |       |
+    | |     |       |
+    | |  +--+--+    |
+    | +->+  B  +<---+
+    | |  +--+--+    |
+    | |     ^       |
+    | |     |       |
+    | |     |       |
+    | |  +--+--+    |
+    | +--+  C  +<---+
+    |    +--+--+
+    |       ^
+    |       |
+    +-------+
+    """
+
+    a -- b -- c -- a drop
+
+    a this befriend
+
+    a b befriend
+    b a befriend
+
+    b c befriend
+    c b befriend
+
+    a parent c same? true assert=
+
+    a.x 100 assert=
+    a.y 200 assert=
+    a.z 300 assert=
+    a.perform 600 assert=
+
+    b.x 100 assert=
+    b.y 200 assert=
+    b.z 300 assert=
+    b.perform 6000000 assert=
+
+    c.x 100 assert=
+    c.y 200 assert=
+    c.z 300 assert=
+    c.perform 6000000 assert=
+  ]
 ]
 
 

--- a/tests/semantics.nk
+++ b/tests/semantics.nk
@@ -48,8 +48,12 @@ describe 'essential lookup' [
 
     a this befriend
 
-    a b adopt
-    b a adopt
+    a -- a drop
+    [ a.inc ] 'definition for x not found in the enclosing block(s)' assertDies
+    200 $: x
+    a.inc 201 assert=
+
+    a -- b -- a drop
 
     a.inc 101 assert=
   ]
@@ -108,6 +112,66 @@ describe 'essential lookup' [
     c.y 200 assert=
     c.z 300 assert=
     c.perform 6000000 assert=
+
+    [ a.foo ] 'no value form for \'foo\'' assertDies
+    [ b.foo ] 'no value form for \'foo\'' assertDies
+    [ c.foo ] 'no value form for \'foo\'' assertDies
+  ]
+
+  it should 'behave as expected in long cyclic chains with edges severed at runtime' [
+    [ 100 $: x ] obj $: a
+    [ 123 $: x ] obj $: o
+    [ 200 $: y ] obj $: b
+    [ 345 $: y ] obj $: m
+    [ 300 $: z ] obj $: c
+
+    a -- o -- b -- c -- a drop
+
+    m toOrphan
+
+    c m befriend
+
+    a.x 100 assert= "in a"
+    a.y 200 assert= "in a -> c -> b"
+    a.z 300 assert= "in a -> c"
+
+    b.x 123 assert= "in b -> o"
+    b.y 200 assert= "in b"
+    b.z 300 assert= "in b -> o -> a -> c"
+
+    c.x 123 assert= "in c -> b -> o"
+    c.y 200 assert= "in c -> b"
+    c.z 300 assert= "in c"
+
+    "Sever edge c -- b"
+    c toOrphan
+
+    a.x 100 assert= "in a"
+    a.y 345 assert= "in a -> c ·> m"
+    a.z 300 assert= "in a -> c"
+
+    b.x 123 assert= "in b -> o"
+    b.y 200 assert= "in b"
+    b.z 300 assert= "in b -> o -> a -> c"
+
+    [ c.x ] 'no value form for \'x\'' assertDies
+    c.y 345 assert= "in c ·> m"
+    c.z 300 assert= "in c"
+
+    "Sever edge a -- o"
+    o toOrphan
+
+    a.x 100 assert= "in a"
+    a.y 345 assert= "in a -> c ·> m"
+    a.z 300 assert= "in a -> c"
+
+    b.x 123 assert= "in b -> o"
+    b.y 200 assert=
+    [ b.z ] 'no value form for \'z\'' assertDies
+
+    [ c.x ] 'no value form for \'x\'' assertDies
+    c.y 345 assert= "in c ·> m"
+    c.z 300 assert= "in c"
   ]
 ]
 

--- a/tests/semantics.nk
+++ b/tests/semantics.nk
@@ -63,29 +63,6 @@ describe 'essential lookup' [
     [ 200 $: y [ [ x y z ] here product ] @: perform ] obj $: b
     [ 300 $: z ] obj $: c
 
-    """
-    +-------+
-    |       |
-    |    +--+--+
-    | +->+  A  +----+
-    | |  +--+--+    |
-    | |     ^       |
-    | |     |       |
-    | |     |       |
-    | |  +--+--+    |
-    | +->+  B  +<---+
-    | |  +--+--+    |
-    | |     ^       |
-    | |     |       |
-    | |     |       |
-    | |  +--+--+    |
-    | +--+  C  +<---+
-    |    +--+--+
-    |       ^
-    |       |
-    +-------+
-    """
-
     a -- b -- c -- a drop
 
     a this befriend
@@ -127,7 +104,7 @@ describe 'essential lookup' [
 
     a -- o -- b -- c -- a drop
 
-    m toOrphan
+    m toOrphan drop
 
     c m befriend
 
@@ -144,7 +121,7 @@ describe 'essential lookup' [
     c.z 300 assert= "in c"
 
     "Sever edge c -- b"
-    c toOrphan
+    c toOrphan drop
 
     a.x 100 assert= "in a"
     a.y 345 assert= "in a -> c ·> m"
@@ -159,7 +136,7 @@ describe 'essential lookup' [
     c.z 300 assert= "in c"
 
     "Sever edge a -- o"
-    o toOrphan
+    o toOrphan drop
 
     a.x 100 assert= "in a"
     a.y 345 assert= "in a -> c ·> m"
@@ -172,6 +149,8 @@ describe 'essential lookup' [
     [ c.x ] 'no value form for \'x\'' assertDies
     c.y 345 assert= "in c ·> m"
     c.z 300 assert= "in c"
+
+    stack count 0 assert=
   ]
 
   it should 'submit properly with cycles, using extendWith' [
@@ -195,7 +174,7 @@ describe 'essential lookup' [
     [ b._x ] 'no value form for \'_x\'' assertDies
 
     b.x 'helloworld' assert=
-    b.y 'world'
+    b.y 'world' assert=
 
     a.x 'hello' assert=
     a.y 'world' assert=
@@ -205,10 +184,164 @@ describe 'essential lookup' [
     a.x 'hello' assert=
     a.y ' Y = world' assert=
 
+    b.x 'helloworld' assert=
+    b.y 'world' assert=
+
     b #y entry:delete "B defines Y = 'world', let's delete that"
 
     b.x 'hello Y = world' assert=
     b.y ' Y = world' assert=
+
+    stack count 0 assert=
+  ]
+
+  it should 'support simple friendship cycles' [
+    [ 100 $: x ] obj $: a
+    [ 200 $: y ] obj $: b
+    [ 300 $: x 'foo' $: z ] obj $: m
+
+    a -- b -- a drop
+    b ·> m ·> b drop
+
+    [ a.x a.y a.z ] vals [ 100 200 'foo' ] assert=
+    [ b.x b.y b.z ] vals [ 100 200 'foo' ] assert=
+    [ m.x m.y m.z ] vals [ 300 200 'foo' ] assert=
+
+    stack count 0 assert=
+  ]
+
+  [ "( B F P -- )"
+     this ahead reparent drop "HACK"
+
+    $: expectedPath
+    $: mirrorForm
+
+    mirrorForm entry:pathTo? true assert=
+
+    mirrorForm assert=
+    expectedPath vals assert=
+  ] @: assertPath
+
+  it should 'reach in more complex friendship cycles/graphs' [
+    [ #x1 $: x1 'a' $: __quote__ ] obj $: a
+    [ #y1 $: y1 'b' $: __quote__ ] obj $: b
+    [ #z1 $: z1 'c' $: __quote__ ] obj $: c
+
+    [ #x2 $: x2 'm' $: __quote__ ] obj $: m
+    [ #y2 $: y2 'n' $: __quote__ ] obj $: n
+
+    [ #x3 $: x3 'q' $: __quote__ ] obj $: q
+
+    "You don't normally see these kinds of graphs, of course.
+     This is just too complex."
+    a -- b -- c -- q drop
+
+    m toOrphan drop
+    m -- n drop
+    m ·> q drop
+
+    """
+    Note: the search for entries is not intelligent (although it very well
+    could have been!), so it simply does a DFS plus some BFS (yeah...) until
+    a definition is found, or no more nodes remain. Unfortunately there is
+    no heuristic (yet) as to where the entry is assumed to be found.
+    """
+
+    a ·> m drop
+    a ·> n drop
+
+    b ·> m drop
+    b ·> n drop
+
+    c ·> m drop
+    c ·> n drop
+
+    """
+    Check reachability of x1, y1, z1 from ALL vertices.
+    """
+
+    a #x1 [ a ] assertPath
+    a #y1 [ a n m q c b ] assertPath "a ·> n ·> m ·> q -> c -> b"
+    a #z1 [ a n m q c ] assertPath "a ·> n ·> m ·> q -> c"
+
+    b #x1 [ b a ] assertPath "b -> a"
+    b #y1 [ b ] assertPath
+    b #z1 [ b n m q c ] assertPath "b ·> n -> m ·> q -> c"
+
+    c #x1 [ c b a ] assertPath "c -> b -> a"
+    c #y1 [ c b ] assertPath "c -> b"
+    c #z1 [ c ] assertPath
+
+    m #x1 [ m q c b a ] assertPath "m ·> q -> c -> b -> a"
+    m #y1 [ m q c b ] assertPath "m ·> q -> c -> b"
+    m #z1 [ m q c ] assertPath "m ·> q -> c"
+
+    n #x1 [ n q c b a ] assertPath "n (-> m) ·> q -> c -> b -> a"
+    n #y1 [ n q c b ] assertPath "n (-> m) ·> q -> c -> b"
+    n #z1 [ n q c ] assertPath "n (-> m) ·> q -> c"
+
+    q #x1 [ q c b a ] assertPath "q -> c -> b -> a"
+    q #y1 [ q c b ] assertPath "q -> c -> b"
+    q #z1 [ q c ] assertPath "q -> c"
+
+    """
+    Check reachability of x2, y2 from ALL vertices.
+    """
+
+    a #x2 [ a m ] assertPath "a ·> m"
+    a #y2 [ a n ] assertPath "a ·> n"
+
+    b #x2 [ b m ] assertPath "b ·> m"
+    b #y2 [ b n ] assertPath "b ·> n"
+
+    c #x2 [ c m ] assertPath "c ·> m"
+    c #y2 [ c n ] assertPath "c ·> n"
+
+    m #x2 [ m ] assertPath
+    m #y2 [ m q c n ] assertPath "m ·> q -> c ·> n"
+
+    n #x2 [ n m ] assertPath "n -> m"
+    n #y2 [ n ] assertPath
+
+    q #x2 [ q c m ] assertPath "q -> c ·> m"
+    q #y2 [ q c n ] assertPath "q -> c ·> n"
+
+    a #x3 [ a n m q ] assertPath "a ·> n -> m ·> q"
+    b #x3 [ b n m q ] assertPath "b ·> n -> m ·> q"
+    c #x3 [ c n m q ] assertPath "c ·> n -> m ·> q"
+
+    m #x3 [ m q ] assertPath "m ·> q"
+    n #x3 [ n m q ] assertPath "n ·> q"
+
+    q #x3 [ q ] assertPath
+
+    [ a.foo ] 'no value form for \'foo\'' assertDies
+    [ b.foo ] 'no value form for \'foo\'' assertDies
+    [ c.foo ] 'no value form for \'foo\'' assertDies
+    [ m.foo ] 'no value form for \'foo\'' assertDies
+    [ n.foo ] 'no value form for \'foo\'' assertDies
+    [ q.foo ] 'no value form for \'foo\'' assertDies
+
+    stack count 0 assert=
+  ]
+
+  it should 'allow friend-parent cycles' [
+    [ #x $: x ] obj $: a
+    [ #y $: y ] obj $: b
+
+    a -- b -- a drop
+    a ·> b ·> a drop
+
+    a #x [ a ] assertPath
+    a #y [ a b ] assertPath
+
+    b #x [ b a ] assertPath
+    b #y [ b ] assertPath
+
+    [ a.foo ] 'no value form for \'foo\'' assertDies
+    [ b.foo ] 'no value form for \'foo\'' assertDies
+
+    stack count 0 assert=
   ]
 ]
 

--- a/tests/semantics.nk
+++ b/tests/semantics.nk
@@ -173,6 +173,43 @@ describe 'essential lookup' [
     c.y 345 assert= "in c ·> m"
     c.z 300 assert= "in c"
   ]
+
+  it should 'submit properly with cycles, using extendWith' [
+    [ 100 $: x ] obj $: a
+    [ 200 $: y ] obj $: b
+
+    a -- b -- a drop
+
+    a.x 100 assert=
+    a.y 200 assert=
+
+    a extend: [ 'hello' $: x
+                'world' =: y ]
+
+    a -> [x y] ['hello' 'world'] assert=
+    b -> [x y] ['hello' 'world'] assert=
+
+    b extend: [ x $: _x [ _x y ~ ] @: x ]
+
+    [ a._x ] 'no value form for \'_x\'' assertDies
+    [ b._x ] 'no value form for \'_x\'' assertDies
+
+    b.x 'helloworld' assert=
+    b.y 'world'
+
+    a.x 'hello' assert=
+    a.y 'world' assert=
+
+    a extend: [ y $: _y [ ' Y = ' _y ~ ] @: y ]
+
+    a.x 'hello' assert=
+    a.y ' Y = world' assert=
+
+    b #y entry:delete "B defines Y = 'world', let's delete that"
+
+    b.x 'hello Y = world' assert=
+    b.y ' Y = world' assert=
+  ]
 ]
 
 

--- a/tests/semantics.nk
+++ b/tests/semantics.nk
@@ -36,6 +36,23 @@ describe 'essential lookup' [
 
     results [ 4 6 8 ] assert=
   ]
+
+  it should 'allow basic lookup cycles' [
+    [
+      [ x 1 + ] @: inc
+    ] obj $: a
+
+    [
+      100 $: x
+    ] obj $: b
+
+    a this befriend
+
+    a b adopt
+    b a adopt
+
+    a.inc 101 assert=
+  ]
 ]
 
 
@@ -224,7 +241,7 @@ describe 'Metawords capability inheritance' [
 
     pathToA disk:read replaceTheFuckingWindowsThing $: aContent
     pathToB disk:read replaceTheFuckingWindowsThing $: bContent
-    
+
     aContent '123.456\n' assert=
     bContent '456.123\n' assert=
 


### PR DESCRIPTION
Needs a lot (and I mean **a lot**) of tests. A huge performance regression. But in theory improves  correctness and  pliability of the language.

Closes #96.